### PR TITLE
refactor: parallelize schedule creation and deduplicate penalty logic

### DIFF
--- a/web/src/components/CreateChoreWizard/CreateChoreWizard.tsx
+++ b/web/src/components/CreateChoreWizard/CreateChoreWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Check, ChevronRight, ChevronLeft, Loader } from 'lucide-react';
+import { Check, ChevronRight, ChevronLeft } from 'lucide-react';
 import clsx from 'clsx';
 import Modal from '../Modal/Modal';
 import { api } from '../../api';
@@ -123,50 +123,40 @@ const CreateChoreWizard: React.FC<Props> = ({ isOpen, onClose, onComplete, users
       });
 
       if (!skipSchedule && schedule.selectedUsers.length > 0) {
-        const errors: string[] = [];
+        const penaltyFields = schedule.dueBy
+          ? { expiry_penalty: schedule.expiryPenalty, expiry_penalty_value: schedule.expiryPenalty === 'penalty' ? schedule.expiryPenaltyValue : 0 }
+          : {};
+        const common = {
+          assignment_type: 'individual' as const,
+          available_at: schedule.availableAt || undefined,
+          due_by: schedule.dueBy || undefined,
+          points_multiplier: 1,
+          ...penaltyFields,
+        };
+
+        const promises: Promise<{ userId: number }>[] = [];
         for (const userId of schedule.selectedUsers) {
-          try {
-            if (schedule.scheduleType === 'weekly') {
-              for (const day of schedule.selectedDays) {
-                await api.chores.createSchedule(created.id, {
-                  assigned_to: userId,
-                  assignment_type: 'individual',
-                  day_of_week: day,
-                  available_at: schedule.availableAt || undefined,
-                  due_by: schedule.dueBy || undefined,
-                  expiry_penalty: schedule.dueBy ? schedule.expiryPenalty : 'block',
-                  expiry_penalty_value: schedule.expiryPenalty === 'penalty' ? schedule.expiryPenaltyValue : 0,
-                  points_multiplier: 1,
-                });
-              }
-            } else if (schedule.scheduleType === 'interval') {
-              await api.chores.createSchedule(created.id, {
-                assigned_to: userId,
-                assignment_type: 'individual',
-                recurrence_interval: schedule.interval,
-                recurrence_start: schedule.intervalStart,
-                available_at: schedule.availableAt || undefined,
-                due_by: schedule.dueBy || undefined,
-                expiry_penalty: schedule.dueBy ? schedule.expiryPenalty : 'block',
-                expiry_penalty_value: schedule.expiryPenalty === 'penalty' ? schedule.expiryPenaltyValue : 0,
-                points_multiplier: 1,
-              });
-            } else {
-              await api.chores.createSchedule(created.id, {
-                assigned_to: userId,
-                assignment_type: 'individual',
-                specific_date: schedule.specificDate,
-                available_at: schedule.availableAt || undefined,
-                due_by: schedule.dueBy || undefined,
-                expiry_penalty: schedule.dueBy ? schedule.expiryPenalty : 'block',
-                expiry_penalty_value: schedule.expiryPenalty === 'penalty' ? schedule.expiryPenaltyValue : 0,
-                points_multiplier: 1,
-              });
+          if (schedule.scheduleType === 'weekly') {
+            for (const day of schedule.selectedDays) {
+              promises.push(
+                api.chores.createSchedule(created.id, { assigned_to: userId, day_of_week: day, ...common }).then(() => ({ userId }))
+              );
             }
-          } catch (e: any) {
-            errors.push(`Schedule for ${users.find(u => u.id === userId)?.name}: ${e.message}`);
+          } else if (schedule.scheduleType === 'interval') {
+            promises.push(
+              api.chores.createSchedule(created.id, { assigned_to: userId, recurrence_interval: schedule.interval, recurrence_start: schedule.intervalStart, ...common }).then(() => ({ userId }))
+            );
+          } else {
+            promises.push(
+              api.chores.createSchedule(created.id, { assigned_to: userId, specific_date: schedule.specificDate, ...common }).then(() => ({ userId }))
+            );
           }
         }
+
+        const results = await Promise.allSettled(promises);
+        const errors = results
+          .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+          .map(r => r.reason?.message || 'Unknown error');
         if (errors.length > 0) {
           setError(`Chore created, but some schedules failed: ${errors.join('; ')}`);
         }

--- a/web/src/pages/AdminDashboard.tsx
+++ b/web/src/pages/AdminDashboard.tsx
@@ -36,12 +36,7 @@ export const AdminDashboard: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!sessionStorage.getItem('openchore_admin')) {
-      navigate('/admin', { replace: true });
-      return;
-    }
     const ensureAdminUser = async () => {
-      // Double-check in case sessionStorage was cleared between the outer check and this running
       if (!sessionStorage.getItem('openchore_admin')) {
         navigate('/admin', { replace: true });
         return;
@@ -308,10 +303,7 @@ const ScheduleManager: React.FC<{
   const [expiryPenalty, setExpiryPenalty] = useState<'block' | 'no_points' | 'penalty'>('block');
   const [expiryPenaltyValue, setExpiryPenaltyValue] = useState('5');
   const [intervalDays, setIntervalDays] = useState('2');
-  const [intervalStart, setIntervalStart] = useState(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
-  });
+  const [intervalStart, setIntervalStart] = useState(() => new Date().toISOString().slice(0, 10));
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
@@ -342,44 +334,32 @@ const ScheduleManager: React.FC<{
     setSaving(true);
 
     try {
-      for (const userId of selectedUsers) {
-        const penaltyFields = dueBy ? {
-          expiry_penalty: expiryPenalty,
-          ...(expiryPenalty === 'penalty' ? { expiry_penalty_value: parseInt(expiryPenaltyValue) || 0 } : {}),
-        } : {};
+      const penaltyFields = dueBy ? {
+        expiry_penalty: expiryPenalty,
+        ...(expiryPenalty === 'penalty' ? { expiry_penalty_value: parseInt(expiryPenaltyValue) || 0 } : {}),
+      } : {};
+      const common = {
+        available_at: availableAt || undefined,
+        due_by: dueBy || undefined,
+        ...penaltyFields,
+      };
 
+      const promises: Promise<unknown>[] = [];
+      for (const userId of selectedUsers) {
         if (schedType === 'recurring') {
           for (const day of selectedDays) {
-            await api.chores.createSchedule(choreId, {
-              assigned_to: userId,
-              day_of_week: day,
-              available_at: availableAt || undefined,
-              due_by: dueBy || undefined,
-              ...penaltyFields,
-            });
+            promises.push(api.chores.createSchedule(choreId, { assigned_to: userId, day_of_week: day, ...common }));
           }
         } else if (schedType === 'interval') {
           const interval = parseInt(intervalDays);
           if (!interval || interval < 1 || !intervalStart) continue;
-          await api.chores.createSchedule(choreId, {
-            assigned_to: userId,
-            recurrence_interval: interval,
-            recurrence_start: intervalStart,
-            available_at: availableAt || undefined,
-            due_by: dueBy || undefined,
-            ...penaltyFields,
-          });
+          promises.push(api.chores.createSchedule(choreId, { assigned_to: userId, recurrence_interval: interval, recurrence_start: intervalStart, ...common }));
         } else {
           if (!specificDate) continue;
-          await api.chores.createSchedule(choreId, {
-            assigned_to: userId,
-            specific_date: specificDate,
-            available_at: availableAt || undefined,
-            due_by: dueBy || undefined,
-            ...penaltyFields,
-          });
+          promises.push(api.chores.createSchedule(choreId, { assigned_to: userId, specific_date: specificDate, ...common }));
         }
       }
+      await Promise.all(promises);
 
       setAdding(false);
       setSelectedDays([]);


### PR DESCRIPTION
Schedule creation for multiple users/days now runs concurrently via
Promise.all instead of sequential awaits, improving responsiveness.
Extracted shared penalty and common fields to reduce copy-paste across
schedule type branches. Removed unused Loader import, redundant
sessionStorage check, and verbose date formatting.

https://claude.ai/code/session_01JaxMJB9z9cp7CMdobLdBZQ