### PR TITLE
docs: rewrite README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # OpenChore
 
-A family chore management system designed for a wall-mounted iPad. Gamifies household tasks with a points economy, rewards store, streaks, and per-kid theming.
+A family chore management system designed for a wall-mounted iPad. Gamifies household tasks with a points economy, rewards store, streaks, approval workflows, and per-kid theming.
 
 ## Features
 
 ### Chore Management
 - **Chore library** with categories: Required, Core, and Bonus
 - **Flexible scheduling**: weekly (pick days), every-N-days interval, or one-off dates
-- **Time locks**: chores hidden until a set time (`available_at`)
+- **Time locks**: chores hidden until a set time (`available_at`), grouped by morning/afternoon/evening
 - **Deadlines**: chores expire after a set time (`due_by`) with configurable penalties
 - **Multi-child assignment**: assign the same schedule to multiple kids at once
+- **Family chores**: `family` assignment type — anyone can complete
+- **Multi-step creation wizard**: guided chore + schedule setup in one flow
+- **Photo proof**: chores can require photo evidence via QR code scan from a second device
+- **Chore triggers**: per-chore webhook URLs for external systems (Home Assistant, etc.) with cooldown and default assignee
+
+### Approval Workflow
+- Chores can require parent approval before points are awarded
+- Admin dashboard shows pending completions for review (approve/reject)
+- Discord notifications for approval requests and chore events (via webhook URL in settings)
 
 ### Points Economy
 - Points earned on chore completion (configurable per chore, with schedule-level multiplier)
@@ -37,33 +46,40 @@ A family chore management system designed for a wall-mounted iPad. Gamifies hous
 - HMAC-SHA256 request signing
 - Delivery logging with response tracking
 
+### Admin
+- **Passcode-protected panel** (PIN-based, no user accounts required; default passcode is `0000`)
+- **Reports dashboard**: weekly/monthly/yearly views with charts — kid scorecards, most-missed chores, completion trends, category breakdown, points flow, day-of-week analysis
+- **Vacation mode**: pause a kid's chores without deleting schedules
+- **Config export**: export current configuration as YAML
+
 ### Theming
 - 4 built-in themes: Default, Quest, Galaxy, Forest
 - Per-kid theme selection with custom category labels, icons, greetings, sounds, and confetti colors
-- Synthesized sound effects on completion
+- Synthesized sound effects on completion (Web Audio API)
 
-### Additional
+### Accessibility
+- **Text-to-speech**: speaker button on chore cards reads title and description aloud (browser SpeechSynthesis API). Defaults on for kids age 7 and under; any user can toggle via header button. Preference persisted per-user.
+- **Swipe-to-complete**: swipe right on a chore card to mark it done (touch devices). Visual green "Done!" hint with 100px threshold.
 - **Ambient dashboard**: wall-mounted family overview mode with auto-rotation between kids
-- **Admin passcode**: PIN-protected admin panel (no user accounts required). The default passcode is `0000`.
-- **Auto-migrations**: database schema managed via embedded SQL migrations
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Go 1.22+, chi/v5 router |
+| Backend | Go 1.25+, chi/v5 router |
 | Database | SQLite3 (WAL mode, foreign keys) |
 | Migrations | golang-migrate with embedded SQL |
 | Frontend | React 18, TypeScript, Vite |
 | Styling | CSS Modules |
 | Icons | lucide-react |
-| Testing | Go standard library + httptest (69 integration tests) |
+| Charts | Custom SVG (BarChart, LineChart components) |
+| Testing | Go standard library + httptest (142 integration tests) |
 | Containers | Multi-stage Alpine builds, Podman/Docker Compose |
 
 ## Getting Started
 
 ### Prerequisites
-- Go 1.22+ with `gcc` (for CGO/sqlite3)
+- Go 1.25+ with `gcc` (for CGO/sqlite3)
 - Node.js 18+ and npm
 
 ### Install Dependencies
@@ -73,7 +89,7 @@ make install
 
 ### Development
 ```bash
-make dev    # Runs API (port 8080) and Vite dev server concurrently
+make dev    # Copies config.example.yaml if needed, wipes DB, runs API (port 8080) and Vite dev server
 ```
 
 Or run them separately:
@@ -82,17 +98,17 @@ make api    # Go API server only
 make ui     # Vite dev server only
 ```
 
+### Seed Data
+
+There is no separate seed command. The server auto-applies `config/config.yaml` on first boot when the database is empty. `make dev` copies `config/config.example.yaml` to `config/config.yaml` if it doesn't exist, wipes the DB, and starts both servers — so seed data is applied automatically.
+
 ### Environment Variables
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `8080` | API server port |
 | `DB_PATH` | `openchore.db` | SQLite database file path |
+| `CONFIG_PATH` | `config/config.yaml` | Path to seed/config YAML file |
 | `TZ` | system | Timezone (important for deadline/time-lock accuracy) |
-
-### Seed Data
-```bash
-make seed   # Populate database with sample users, chores, and schedules
-```
 
 ### Running Tests
 ```bash
@@ -117,35 +133,54 @@ The compose setup runs:
 
 ```
 .
-├── cmd/server/main.go        # Entry point: migrations, background workers, HTTP server
+├── cmd/server/main.go        # Entry point: migrations, config seeding, background workers, HTTP server
+├── config/
+│   └── config.example.yaml   # Development seed data (users, chores, schedules, rewards, webhooks)
 ├── internal/
 │   ├── api/                  # HTTP handlers and router
 │   │   ├── router.go         # Route definitions and middleware
-│   │   ├── chores.go         # Chore CRUD, schedules, completions
+│   │   ├── chores.go         # Chore CRUD, schedules, completions, approvals, photo upload
+│   │   ├── triggers.go       # Per-chore trigger webhooks
 │   │   ├── points.go         # Points balance, adjustments, decay config
 │   │   ├── rewards.go        # Rewards store, redemptions
-│   │   └── api_test.go       # Integration test suite (69 tests)
-│   ├── model/model.go        # Data types (User, Chore, Schedule, etc.)
+│   │   ├── reports.go        # Admin analytics/reports
+│   │   ├── api_test.go       # Integration test suite
+��   │   ├── reports_test.go   # Reports endpoint tests
+│   │   └── triggers_test.go  # Trigger endpoint tests
+│   ├── discord/              # Discord webhook notifications
+│   │   └── notifier.go       # Sends approval requests, chore events to Discord
+│   ├── model/model.go        # Data types (User, Chore, Schedule, Trigger, etc.)
 │   ├── store/store.go        # SQLite data access layer
 │   └── webhook/              # Async webhook dispatcher + background checkers
 │       ├── dispatcher.go     # Event firing, HMAC signing, delivery logging
 │       ├── expiry.go         # Background expiry checker (1-min interval)
 │       └── decay.go          # Background decay checker (15-min interval)
-├── migrations/               # Embedded SQL migrations (001-008)
+├── migrations/               # Embedded SQL migrations (001–006)
 ├── web/                      # React frontend
 │   └── src/
 │       ├── api.ts            # Typed API client
-│       ├── types.ts          # TypeScript interfaces
+│       ├── types.ts          # TypeScript interfaces + theme config
 │       ├── pages/
 │       │   ├── Dashboard.tsx          # Kid view (daily/weekly/rewards)
-│       │   ├── AdminDashboard.tsx     # Admin panel (chores/rewards/points/settings)
+│       │   ├── AdminDashboard.tsx     # Admin panel (chores/users/rewards/points/settings)
+│       │   ├── AdminPasscode.tsx      # PIN entry screen
 │       │   ├── AmbientDashboard.tsx   # Wall-mounted family overview
-│       │   └── ProfileSelection.tsx   # User picker
-│       └── hooks/            # useIdleRedirect, useThemeSound
+│       │   ├── PhotoUpload.tsx        # QR-scanned photo upload page
+│       │   ├── ProfileSelection.tsx   # User picker
+│       │   ├── Reports.tsx            # Admin analytics with charts
+│       │   └── SetupWizard.tsx        # First-boot setup flow
+│       ├── components/
+│       │   ├── Modal/                 # Reusable modal component
+│       │   ├── CreateChoreWizard/     # Multi-step chore creation
+│       │   ├── EditChoreModal/        # Chore editing with schedules + triggers
+│       │   └── charts/               # BarChart and LineChart (SVG)
+│       └── hooks/
+│           ├─��� useIdleRedirect.ts     # Auto-redirect after inactivity
+│           ├── useTextToSpeech.ts     # Browser SpeechSynthesis wrapper
+│           └── useThemeSound.ts       # Web Audio API completion sounds
 ├── compose.yaml              # Container orchestration
 ├── Containerfile             # Multi-stage Go build
-├── Makefile                  # Dev/build/test commands
-└── seed.go                   # Sample data seeder
+└── Makefile                  # Dev/build/test commands
 ```
 
 ## API Reference
@@ -156,6 +191,8 @@ The compose setup runs:
 | GET | `/api/users` | List all users |
 | GET | `/api/users/{id}` | Get user details |
 | POST | `/api/admin/verify` | Verify admin passcode |
+| POST | `/api/setup` | Initial setup (only when no users exist) |
+| POST | `/api/hooks/trigger/{uuid}` | Fire a chore trigger (UUID is auth) |
 
 ### Authenticated (`X-User-ID` header)
 | Method | Path | Description |
@@ -163,10 +200,12 @@ The compose setup runs:
 | GET | `/api/users/{id}/chores?view=daily&date=YYYY-MM-DD` | Get scheduled chores |
 | POST | `/api/schedules/{id}/complete` | Complete a chore |
 | DELETE | `/api/schedules/{id}/complete?date=YYYY-MM-DD` | Undo completion |
+| POST | `/api/upload` | Upload photo proof |
 | GET | `/api/users/{id}/points` | Get point balance + history |
 | GET | `/api/users/{id}/streak` | Get streak data |
 | GET | `/api/rewards` | List available rewards |
 | POST | `/api/rewards/{id}/redeem` | Redeem a reward |
+| GET | `/api/users/{id}/redemptions` | Redemption history |
 | PUT | `/api/users/{id}/theme` | Update theme preference |
 | PUT | `/api/users/{id}/avatar` | Update avatar URL |
 
@@ -176,17 +215,31 @@ The compose setup runs:
 | POST | `/api/users` | Create user |
 | PUT | `/api/users/{id}` | Update user |
 | DELETE | `/api/users/{id}` | Delete user |
-| POST/PUT/DELETE | `/api/chores[/{id}]` | Chore CRUD |
-| POST/DELETE | `/api/chores/{id}/schedules[/{sid}]` | Schedule management |
-| POST/PUT/DELETE | `/api/rewards[/{id}]` | Reward CRUD |
+| PUT | `/api/users/{id}/pause` | Pause user (vacation mode) |
+| PUT | `/api/users/{id}/unpause` | Unpause user |
+| GET/POST | `/api/chores[/{id}]` | Chore list/create |
+| GET/PUT/DELETE | `/api/chores/{id}` | Chore read/update/delete |
+| GET/POST | `/api/chores/{id}/schedules` | Schedule list/create |
+| DELETE | `/api/chores/{id}/schedules/{sid}` | Delete schedule |
+| GET/POST | `/api/chores/{id}/triggers` | Trigger list/create |
+| PUT/DELETE | `/api/triggers/{id}` | Update/delete trigger |
+| GET | `/api/completions/pending` | List pending approvals |
+| POST | `/api/completions/{id}/approve` | Approve completion |
+| POST | `/api/completions/{id}/reject` | Reject completion |
+| GET/PUT | `/api/admin/settings/{key}` | Read/write settings |
+| PUT | `/api/admin/passcode` | Update admin PIN |
+| GET | `/api/points/balances` | All user balances |
+| POST | `/api/points/adjust` | Manual point adjustment |
+| GET/PUT | `/api/admin/users/{id}/decay` | Decay config per user |
+| GET/POST | `/api/rewards[/all]` | Reward list/create |
+| PUT/DELETE | `/api/rewards/{id}` | Update/delete reward |
 | PUT | `/api/rewards/{id}/assignments` | Per-kid reward visibility |
 | DELETE | `/api/redemptions/{id}` | Undo redemption |
-| POST | `/api/points/adjust` | Manual point adjustment |
-| GET | `/api/points/balances` | All user balances |
-| GET/PUT | `/api/admin/users/{id}/decay` | Decay config per user |
-| POST/PUT/DELETE | `/api/admin/webhooks[/{id}]` | Webhook management |
-| PUT | `/api/admin/passcode` | Update admin PIN |
-| POST/DELETE | `/api/admin/streak-rewards[/{id}]` | Streak milestone management |
+| GET/POST/DELETE | `/api/admin/streak-rewards[/{id}]` | Streak milestone CRUD |
+| GET | `/api/admin/reports` | Analytics/reports data |
+| GET | `/api/admin/export-config` | Export config as YAML |
+| GET/POST/PUT/DELETE | `/api/admin/webhooks[/{id}]` | Webhook CRUD |
+| GET | `/api/admin/webhooks/{id}/deliveries` | Webhook delivery log |
 
 ## Chore Categories
 


### PR DESCRIPTION
## Summary

The README was significantly out of date. Validated every claim against the codebase and rewrote it to match reality.

- **Fixed inaccuracies**: Go version (1.22+ → 1.25+), test count (69 → 142), migration count (001–008 → 001–006), removed nonexistent `make seed` target
- **Added missing features**: approval workflow, photo proof/QR flow, chore triggers, Discord notifications, reports dashboard, vacation mode, family chores, TTS, swipe-to-complete, config-based seeding, creation wizard, time-of-day grouping
- **Complete API reference**: was 19 routes, now documents all 36+ routes organized by auth level
- **Updated project structure**: added all pages (PhotoUpload, Reports, SetupWizard, AdminPasscode), components (Modal, CreateChoreWizard, EditChoreModal, charts), hooks (useTextToSpeech), and directories (discord/, config/)
- **Added `CONFIG_PATH` env var** and corrected seed data documentation

## Test plan

- [ ] Read through the README and spot-check claims against the codebase
- [ ] Verify all listed API routes match `internal/api/router.go`
- [ ] Verify project structure tree matches actual file layout

https://claude.ai/code/session_01JaxMJB9z9cp7CMdobLdBZQ