### PR TITLE
fix: restore points decay + missed-chore penalties on non-required chores

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,6 +67,8 @@ func main() {
 	go expiryChecker.Start(context.Background())
 	decayChecker := webhook.NewDecayChecker(s, dispatcher)
 	go decayChecker.Start(context.Background())
+	pointsDecayChecker := webhook.NewPointsDecayChecker(s, dispatcher)
+	go pointsDecayChecker.Start(context.Background())
 
 	router, choreHandler, reportsHandler := api.NewRouter(s, dispatcher)
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -258,6 +258,59 @@ func TestChoreCRUD(t *testing.T) {
 	}
 }
 
+// TestChoreUpdatePointsAndPenaltyZeroing verifies that points_value and
+// missed_penalty_value can be explicitly set to 0 via a PUT, and that a
+// partial update that omits those fields leaves them untouched.
+func TestChoreUpdatePointsAndPenaltyZeroing(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+
+	// Create a chore with non-zero points and penalty.
+	resp := env.request(t, "POST", "/api/chores", map[string]any{
+		"title":                "Take out trash",
+		"category":             "core",
+		"points_value":         10,
+		"missed_penalty_value": 5,
+	}, adminHeaders())
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	var chore map[string]any
+	decodeBody(t, resp, &chore)
+	choreID := int(chore["id"].(float64))
+
+	// Partial update: title only. Points and penalty should be preserved.
+	resp = env.request(t, "PUT", fmt.Sprintf("/api/chores/%d", choreID), map[string]any{
+		"title": "Take out trash (evening)",
+	}, adminHeaders())
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("partial update: expected 200, got %d", resp.StatusCode)
+	}
+	decodeBody(t, resp, &chore)
+	if chore["points_value"].(float64) != 10 {
+		t.Errorf("partial update clobbered points_value: got %v, want 10", chore["points_value"])
+	}
+	if chore["missed_penalty_value"].(float64) != 5 {
+		t.Errorf("partial update clobbered missed_penalty_value: got %v, want 5", chore["missed_penalty_value"])
+	}
+
+	// Explicit zero: both fields should be cleared.
+	resp = env.request(t, "PUT", fmt.Sprintf("/api/chores/%d", choreID), map[string]any{
+		"points_value":         0,
+		"missed_penalty_value": 0,
+	}, adminHeaders())
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("zero update: expected 200, got %d", resp.StatusCode)
+	}
+	decodeBody(t, resp, &chore)
+	if chore["points_value"].(float64) != 0 {
+		t.Errorf("explicit zero was ignored for points_value: got %v, want 0", chore["points_value"])
+	}
+	if chore["missed_penalty_value"].(float64) != 0 {
+		t.Errorf("explicit zero was ignored for missed_penalty_value: got %v, want 0", chore["missed_penalty_value"])
+	}
+}
+
 func TestScheduleAndComplete(t *testing.T) {
 	env := setupTest(t)
 	env.createAdmin(t)

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -73,12 +73,15 @@ func (h *ChoreHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 type createChoreRequest struct {
-	Title              string `json:"title"`
-	Description        string `json:"description"`
-	Category           string `json:"category"`
-	Icon               string `json:"icon"`
-	PointsValue        int    `json:"points_value"`
-	MissedPenaltyValue int    `json:"missed_penalty_value"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	Icon        string `json:"icon"`
+	// PointsValue and MissedPenaltyValue are pointers so we can distinguish
+	// "field omitted" (nil) from "field explicitly set to 0". Without this,
+	// admins can't clear a penalty or zero out a point value via the UI.
+	PointsValue        *int   `json:"points_value"`
+	MissedPenaltyValue *int   `json:"missed_penalty_value"`
 	EstimatedMinutes   *int   `json:"estimated_minutes"`
 	RequiresApproval   bool   `json:"requires_approval"`
 	RequiresPhoto      bool   `json:"requires_photo"`
@@ -118,8 +121,8 @@ func (h *ChoreHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Description:        req.Description,
 		Category:           req.Category,
 		Icon:               req.Icon,
-		PointsValue:        req.PointsValue,
-		MissedPenaltyValue: req.MissedPenaltyValue,
+		PointsValue:        intPtrOrZero(req.PointsValue),
+		MissedPenaltyValue: intPtrOrZero(req.MissedPenaltyValue),
 		EstimatedMinutes:   req.EstimatedMinutes,
 		RequiresApproval:   req.RequiresApproval,
 		RequiresPhoto:      req.RequiresPhoto,
@@ -193,11 +196,14 @@ func (h *ChoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.Icon != "" {
 		existing.Icon = req.Icon
 	}
-	if req.PointsValue != 0 {
-		existing.PointsValue = req.PointsValue
+	// Honor an explicit 0 (nil == field omitted, non-nil == set to that
+	// value). This lets admins clear a penalty or reset points to zero via
+	// the UI rather than having the update silently dropped.
+	if req.PointsValue != nil {
+		existing.PointsValue = *req.PointsValue
 	}
-	if req.MissedPenaltyValue != 0 {
-		existing.MissedPenaltyValue = req.MissedPenaltyValue
+	if req.MissedPenaltyValue != nil {
+		existing.MissedPenaltyValue = *req.MissedPenaltyValue
 	}
 	if req.EstimatedMinutes != nil {
 		existing.EstimatedMinutes = req.EstimatedMinutes
@@ -523,10 +529,10 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 					writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
 						"error": result.Feedback,
 						"ai_review": map[string]any{
-							"complete":        result.Complete,
-							"confidence":      result.Confidence,
-							"feedback":        result.Feedback,
-							"feedback_audio":  feedbackAudioURL,
+							"complete":       result.Complete,
+							"confidence":     result.Confidence,
+							"feedback":       result.Feedback,
+							"feedback_audio": feedbackAudioURL,
 						},
 					})
 					return

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -30,3 +30,12 @@ func decodeJSON(r *http.Request, v any) error {
 	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)
 }
+
+// intPtrOrZero returns *p if p is non-nil, otherwise 0. Used for request
+// fields that are *int so we can tell "omitted" (nil) from "explicitly 0".
+func intPtrOrZero(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/internal/webhook/decay.go
+++ b/internal/webhook/decay.go
@@ -1,0 +1,138 @@
+package webhook
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/liftedkilt/openchore/internal/model"
+	"github.com/liftedkilt/openchore/internal/store"
+)
+
+// PointsDecayChecker runs periodically and debits points from kids whose
+// non-bonus chores were not all completed the previous day, according to the
+// per-user settings in user_decay_config.
+//
+// This is distinct from DecayChecker in penalty.go, which (despite its name)
+// handles per-chore "missed required chore" penalties.
+type PointsDecayChecker struct {
+	store      *store.Store
+	dispatcher *Dispatcher
+	interval   time.Duration
+}
+
+func NewPointsDecayChecker(s *store.Store, d *Dispatcher) *PointsDecayChecker {
+	return &PointsDecayChecker{
+		store:      s,
+		dispatcher: d,
+		interval:   15 * time.Minute,
+	}
+}
+
+func (pdc *PointsDecayChecker) Start(ctx context.Context) {
+	// Run an immediate check on startup so decays are applied promptly after
+	// a restart rather than having to wait a full tick.
+	pdc.check(ctx)
+
+	ticker := time.NewTicker(pdc.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pdc.check(ctx)
+		}
+	}
+}
+
+func (pdc *PointsDecayChecker) check(ctx context.Context) {
+	configs, err := pdc.store.ListDecayConfigsEnabled(ctx)
+	if err != nil {
+		log.Printf("points-decay: failed to list decay configs: %v", err)
+		return
+	}
+
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1).Format(model.DateFormat)
+
+	for _, cfg := range configs {
+		// Respect the per-user decay interval: skip users who were decayed
+		// more recently than decay_interval_hours ago.
+		if cfg.LastDecayAt != nil {
+			elapsed := now.Sub(*cfg.LastDecayAt)
+			if elapsed < time.Duration(cfg.DecayIntervalHours)*time.Hour {
+				continue
+			}
+		}
+
+		user, err := pdc.store.GetUser(ctx, cfg.UserID)
+		if err != nil {
+			log.Printf("points-decay: failed to load user %d: %v", cfg.UserID, err)
+			continue
+		}
+		if user == nil || user.Role != "child" || user.Paused {
+			continue
+		}
+
+		// The rule (see README): decay only if any non-bonus chore was not
+		// completed yesterday. Bonus chores are ignored.
+		chores, err := pdc.store.GetScheduledChoresForUser(ctx, cfg.UserID, []string{yesterday}, now)
+		if err != nil {
+			log.Printf("points-decay: failed to list chores for user %d: %v", cfg.UserID, err)
+			continue
+		}
+
+		nonBonusCount := 0
+		missedAny := false
+		for _, c := range chores {
+			if c.Category == model.CategoryBonus {
+				continue
+			}
+			nonBonusCount++
+			if !c.Completed {
+				missedAny = true
+			}
+		}
+
+		// No non-bonus chores scheduled or everything was completed: no
+		// decay, but still advance the timer so we don't keep re-checking.
+		if nonBonusCount == 0 || !missedAny {
+			if err := pdc.store.UpdateLastDecayAt(ctx, cfg.UserID, now); err != nil {
+				log.Printf("points-decay: failed to update last_decay_at for user %d: %v", cfg.UserID, err)
+			}
+			continue
+		}
+
+		// Clamp the debit so decay never pushes the balance negative.
+		balance, err := pdc.store.GetPointBalance(ctx, cfg.UserID)
+		if err != nil {
+			log.Printf("points-decay: failed to get balance for user %d: %v", cfg.UserID, err)
+			continue
+		}
+		debit := cfg.DecayRate
+		if debit > balance {
+			debit = balance
+		}
+
+		if debit > 0 {
+			if err := pdc.store.DebitDecay(ctx, cfg.UserID, debit); err != nil {
+				log.Printf("points-decay: failed to debit user %d: %v", cfg.UserID, err)
+				continue
+			}
+			log.Printf("points-decay: debited %d points from user %d (%s) for missed chores on %s", debit, user.ID, user.Name, yesterday)
+
+			pdc.dispatcher.Fire(EventPointsDecayed, map[string]any{
+				"user_id":   user.ID,
+				"user_name": user.Name,
+				"amount":    debit,
+				"date":      yesterday,
+			})
+		}
+
+		if err := pdc.store.UpdateLastDecayAt(ctx, cfg.UserID, now); err != nil {
+			log.Printf("points-decay: failed to update last_decay_at for user %d: %v", cfg.UserID, err)
+		}
+	}
+}

--- a/internal/webhook/penalty.go
+++ b/internal/webhook/penalty.go
@@ -61,8 +61,10 @@ func (pc *DecayChecker) check(ctx context.Context) {
 		}
 
 		for _, c := range chores {
-			// Only penalize required chores that weren't completed and have a penalty value
-			if c.Category == model.CategoryRequired && !c.Completed && c.MissedPenaltyValue > 0 {
+			// Penalize any non-bonus chore (required or core) that wasn't
+			// completed and has a configured missed-penalty value. Bonus
+			// chores are optional and never incur a missed-chore penalty.
+			if c.Category != model.CategoryBonus && !c.Completed && c.MissedPenaltyValue > 0 {
 				// Check if already penalized to avoid double-dipping
 				alreadyPenalized, err := pc.store.HasMissedChorePenalty(ctx, c.ScheduleID, yesterday)
 				if err != nil {

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -798,3 +798,274 @@ func TestDecayChecker_OnlyPenalizesChildren(t *testing.T) {
 		t.Error("parents should not be penalized for missed chores")
 	}
 }
+
+// --- PointsDecayChecker Tests ---
+
+func TestNewPointsDecayChecker(t *testing.T) {
+	env := setupTest(t)
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	if pdc == nil {
+		t.Fatal("NewPointsDecayChecker returned nil")
+	}
+	if pdc.interval != 15*time.Minute {
+		t.Errorf("expected interval 15m, got %v", pdc.interval)
+	}
+}
+
+func TestPointsDecayChecker_StartAndCancel(t *testing.T) {
+	env := setupTest(t)
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.interval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		pdc.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("PointsDecayChecker.Start did not return after context cancel")
+	}
+}
+
+func TestPointsDecayChecker_DecaysWhenRequiredChoreMissed(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	var mu sync.Mutex
+	var firedEvents []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		firedEvents = append(firedEvents, r.Header.Get("X-OpenChore-Event"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	createWebhook(t, env, ts.URL, "", "*", true)
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+
+	// Seed a balance so we can observe the debit.
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	// A required chore that was scheduled yesterday and NOT completed.
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	// Enable decay for this child at 7 points/day.
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 7, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, err := env.store.GetPointBalance(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetPointBalance: %v", err)
+	}
+	if balance != 93 {
+		t.Errorf("expected balance 93 after decay, got %d", balance)
+	}
+
+	// last_decay_at should be set so we don't re-decay on the next tick.
+	cfg, _ := env.store.GetUserDecayConfig(ctx, childID)
+	if cfg.LastDecayAt == nil {
+		t.Error("expected last_decay_at to be set after decay")
+	}
+
+	// Running again immediately must not decay again (interval respected).
+	pdc.check(ctx)
+	balance2, _ := env.store.GetPointBalance(ctx, childID)
+	if balance2 != 93 {
+		t.Errorf("expected balance to remain 93 on second check, got %d", balance2)
+	}
+
+	// Webhook for points.decayed should have fired exactly once.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	decayedCount := 0
+	for _, e := range firedEvents {
+		if e == EventPointsDecayed {
+			decayedCount++
+		}
+	}
+	if decayedCount != 1 {
+		t.Errorf("expected 1 %q webhook event, got %d (events=%v)", EventPointsDecayed, decayedCount, firedEvents)
+	}
+}
+
+func TestPointsDecayChecker_NoDecayWhenAllChoresComplete(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	_, scheduleID := createChoreWithSchedule(t, env, parentID, childID, "core", int(yesterday.Weekday()), nil, 0)
+
+	// Mark yesterday's chore as completed.
+	if err := env.store.CompleteChore(ctx, &model.ChoreCompletion{
+		ChoreScheduleID: scheduleID,
+		CompletedBy:     childID,
+		Status:          model.StatusApproved,
+		CompletionDate:  yesterday.Format(model.DateFormat),
+	}); err != nil {
+		t.Fatalf("CompleteChore: %v", err)
+	}
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 5, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 100 {
+		t.Errorf("expected balance to stay at 100, got %d", balance)
+	}
+}
+
+func TestPointsDecayChecker_IgnoresBonusChores(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+	if err := env.store.AdminAdjustPoints(ctx, childID, 50, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	// Only a bonus chore scheduled for yesterday, incomplete.
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "bonus", int(yesterday.Weekday()), nil, 0)
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 5, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 50 {
+		t.Errorf("bonus-only misses must not trigger decay; balance=%d want 50", balance)
+	}
+}
+
+func TestPointsDecayChecker_RespectsIntervalHours(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 5, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	// Simulate a decay that already ran 1 hour ago.
+	recent := time.Now().Add(-1 * time.Hour)
+	if err := env.store.UpdateLastDecayAt(ctx, childID, recent); err != nil {
+		t.Fatalf("UpdateLastDecayAt: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 100 {
+		t.Errorf("expected balance to stay at 100 (interval not elapsed), got %d", balance)
+	}
+}
+
+func TestPointsDecayChecker_SkipsDisabledUsers(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	// Explicitly disabled.
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: false, DecayRate: 5, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 100 {
+		t.Errorf("disabled user should not be decayed; balance=%d want 100", balance)
+	}
+}
+
+func TestPointsDecayChecker_ClampsToNonNegativeBalance(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+
+	// Only 3 points in the bank; decay rate is 10.
+	if err := env.store.AdminAdjustPoints(ctx, childID, 3, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 10, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 0 {
+		t.Errorf("expected balance clamped to 0, got %d", balance)
+	}
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -701,6 +701,40 @@ func TestDecayChecker_PenalizeMissedRequiredChore(t *testing.T) {
 	}
 }
 
+func TestDecayChecker_PenalizeMissedCoreChore(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+
+	// Seed a positive balance so we can observe the debit.
+	if err := env.store.AdminAdjustPoints(ctx, childID, 50, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	// A core chore scheduled for yesterday with a 7-point missed penalty.
+	yesterday := time.Now().AddDate(0, 0, -1)
+	dow := int(yesterday.Weekday())
+	_, scheduleID := createChoreWithSchedule(t, env, parentID, childID, "core", dow, nil, 7)
+
+	dc := NewDecayChecker(env.store, env.dispatcher)
+	dc.check(ctx)
+
+	hasPenalty, err := env.store.HasMissedChorePenalty(ctx, scheduleID, yesterday.Format(model.DateFormat))
+	if err != nil {
+		t.Fatalf("HasMissedChorePenalty error: %v", err)
+	}
+	if !hasPenalty {
+		t.Error("expected missed core chore with penalty to be debited")
+	}
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 43 {
+		t.Errorf("expected balance=43 after 7-point penalty on missed core chore, got %d", balance)
+	}
+}
+
 func TestDecayChecker_NoPenaltyForBonusChore(t *testing.T) {
 	env := setupTest(t)
 


### PR DESCRIPTION
## Summary

Three related fixes to the points-economy side of the app, all user-reported:

### 1. Points decay was never actually running (`cf3a99a`)

Enabling per-user points decay did nothing: no debit, no webhook, no log line. The store methods (`ListDecayConfigsEnabled`, `DebitDecay`, `UpdateLastDecayAt`), the admin API, the `user_decay_config` table, and the `points.decayed` webhook event all existed — but nothing in `cmd/server/main.go` ever invoked them. The `DecayChecker` in `internal/webhook/penalty.go` that looked like it should handle this is actually the missed-required-chore penalty checker, per its own comment (kept the old name to avoid breaking initialization).

- New `internal/webhook/decay.go` with `PointsDecayChecker`: runs on startup then every 15 minutes, honors each user's `decay_interval_hours`, only debits when a non-bonus chore was missed yesterday (per README line 32), clamps debits to current balance so decay cannot push a kid into the red, updates `last_decay_at`, and fires the `points.decayed` webhook.
- Wired up in `cmd/server/main.go` alongside the existing expiry and penalty checkers.
- Emits a log line on each debit so you can see it happening.
- 7 new tests covering: constructor, start/cancel, debit-on-miss, no-decay-when-complete, bonus-only exemption, interval enforcement, disabled-user skip, and non-negative balance clamping.

### 2. Missed-chore penalty only fired for required chores (`b7993b4`)

Both `CreateChoreWizard` and `EditChoreModal` let you set a Penalty value on any chore category, and the field saved to the DB correctly — but `internal/webhook/penalty.go:65` gated the debit on `c.Category == model.CategoryRequired`, so core chores with a configured penalty were silently ignored. The check now allows any non-bonus chore (bonus chores remain exempt — see `TestDecayChecker_NoPenaltyForBonusChore`).

- New `TestDecayChecker_PenalizeMissedCoreChore` locks in the restored behavior.

### 3. Couldn't clear `points_value` or `missed_penalty_value` to 0 (`f568d01`)

The chore Update handler guarded `PointsValue` and `MissedPenaltyValue` with `if req.Field != 0`, silently dropping any attempt to reset either field back to 0 via the admin UI. Switched both to `*int` in the request struct so nil means "omitted" and a non-nil zero means "explicitly set to 0". This also preserves partial-PUT semantics — a title-only update no longer has the potential to clobber the stored values.

- Added `intPtrOrZero` helper in `internal/api/helpers.go` for the Create path.
- New `TestChoreUpdatePointsAndPenaltyZeroing` verifies both that explicit zero clears the value *and* that a partial PUT leaves untouched fields alone.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all green (includes 9 new tests)
- [ ] Manually verify after deploy: enable decay on a kid, have them miss a core chore, confirm balance drops and log line appears
- [ ] Manually verify: edit a chore that has a 5-point penalty, set penalty to 0, confirm it saves and the next day's missed-chore check does not debit

https://claude.ai/code/session_01H19SgGFTVDfthZBZioqXzu