### PR TITLE
fix: remove admin theme option and make AI summary init resilient

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,15 +105,19 @@ func initAIServices(s *store.Store, choreHandler *api.ChoreHandler, reportsHandl
 
 	aiClient := aibackend.NewClient(aiEndpoint)
 
-	// Wait for the AI endpoint to become available (retry every 5s for up to 2 minutes)
+	// Wait for the AI endpoint to become available. Retry forever so that a
+	// slow-to-start sidecar (or one started after the server) still wires up
+	// AI features — previously this gave up after 2 minutes and left the
+	// summarizer/reviewer permanently nil, which surfaced in the UI as
+	// "AI services may not be available" with no way to recover short of a
+	// server restart.
 	log.Printf("Waiting for AI endpoint at %s...", aiEndpoint)
-	for attempt := 1; attempt <= 24; attempt++ {
+	for attempt := 1; ; attempt++ {
 		if aiClient.Healthy(context.Background()) {
 			break
 		}
-		if attempt == 24 {
-			log.Printf("AI endpoint not available at %s after 2 minutes — AI features disabled", aiEndpoint)
-			return
+		if attempt%12 == 0 {
+			log.Printf("Still waiting for AI endpoint at %s (attempt %d)", aiEndpoint, attempt)
 		}
 		time.Sleep(5 * time.Second)
 	}
@@ -123,14 +127,20 @@ func initAIServices(s *store.Store, choreHandler *api.ChoreHandler, reportsHandl
 		aiModel = "gemma4:e4b"
 	}
 
-	// Auto-pull model if not present
-	if !aiClient.HasModel(context.Background(), aiModel) {
+	// Auto-pull model if not present. Retry transient failures so a flaky
+	// pull doesn't permanently disable AI features.
+	for attempt := 1; ; attempt++ {
+		if aiClient.HasModel(context.Background(), aiModel) {
+			break
+		}
 		log.Printf("Model %s not found — pulling (this may take a few minutes on first run)...", aiModel)
 		if err := aiClient.Pull(context.Background(), aiModel); err != nil {
-			log.Printf("WARNING: failed to pull model %s: %v — AI features disabled", aiModel, err)
-			return
+			log.Printf("WARNING: failed to pull model %s (attempt %d): %v — retrying in 30s", aiModel, attempt, err)
+			time.Sleep(30 * time.Second)
+			continue
 		}
 		log.Printf("Model %s pulled successfully", aiModel)
+		break
 	}
 
 	reviewer := ai.NewReviewer(aiClient, aiModel)

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -74,12 +74,17 @@ func (h *UserHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	theme := req.Theme
+	if req.Role == "admin" {
+		// Admin users never have a theme — the admin UI always uses the default.
+		theme = ""
+	}
 	user := &model.User{
 		Name:      req.Name,
 		AvatarURL: req.AvatarURL,
 		Role:      req.Role,
 		Age:       req.Age,
-		Theme:     req.Theme,
+		Theme:     theme,
 	}
 	if err := h.store.CreateUser(r.Context(), user); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create user")
@@ -125,8 +130,12 @@ func (h *UserHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.Age != nil {
 		existing.Age = req.Age
 	}
-	if req.Theme != "" {
+	if req.Theme != "" && existing.Role != "admin" {
 		existing.Theme = req.Theme
+	}
+	if existing.Role == "admin" {
+		// Admin users never have a theme — clear any stale value.
+		existing.Theme = ""
 	}
 
 	if err := h.store.UpdateUser(r.Context(), existing); err != nil {
@@ -147,6 +156,12 @@ func (h *UserHandler) UpdateTheme(w http.ResponseWriter, r *http.Request) {
 	caller := UserFromContext(r.Context())
 	if caller.ID != id {
 		writeError(w, http.StatusForbidden, "can only update your own theme")
+		return
+	}
+
+	// Admin users do not have themes — the admin UI always uses the default.
+	if caller.Role == "admin" {
+		writeError(w, http.StatusForbidden, "admin users do not have themes")
 		return
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -48,10 +48,15 @@ func Apply(ctx context.Context, s *store.Store, cfg *Config) error {
 	// 1. Create users, build name→ID map
 	nameToID := make(map[string]int64, len(cfg.Users))
 	for _, u := range cfg.Users {
+		theme := u.Theme
+		if u.Role == "admin" {
+			// Admin users never have a theme — the admin UI always uses the default.
+			theme = ""
+		}
 		user := &model.User{
 			Name:      u.Name,
 			Role:      u.Role,
-			Theme:     u.Theme,
+			Theme:     theme,
 			AvatarURL: u.Avatar,
 		}
 		if u.Age > 0 {

--- a/migrations/011_clear_admin_theme.down.sql
+++ b/migrations/011_clear_admin_theme.down.sql
@@ -1,0 +1,2 @@
+-- No-op: clearing admin themes is not reversible (we don't know the prior value).
+SELECT 1;

--- a/migrations/011_clear_admin_theme.up.sql
+++ b/migrations/011_clear_admin_theme.up.sql
@@ -1,0 +1,3 @@
+-- Clear any stored theme value on admin users. Admins never have a theme —
+-- the admin UI always uses the default styling.
+UPDATE users SET theme = '' WHERE role = 'admin';

--- a/web/src/ThemeContext.tsx
+++ b/web/src/ThemeContext.tsx
@@ -17,7 +17,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [theme, setThemeState] = useState<Theme>('default');
 
   useEffect(() => {
-    if (user?.theme) {
+    // Admin users never get a theme — the admin UI always uses the default.
+    if (user?.role === 'admin') {
+      setThemeState('default');
+    } else if (user?.theme) {
       setThemeState(user.theme as Theme);
     } else if (!user) {
       setThemeState('default');
@@ -29,6 +32,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, [theme]);
 
   const setTheme = async (newTheme: Theme) => {
+    // Admin users cannot change their theme.
+    if (user?.role === 'admin') return;
     setThemeState(newTheme);
     if (user) {
       try {

--- a/web/src/components/admin/UsersTab.tsx
+++ b/web/src/components/admin/UsersTab.tsx
@@ -82,6 +82,8 @@ const UserForm: React.FC<{
   const [userTheme, setUserTheme] = useState<Theme>(user?.theme || 'default');
   const [saving, setSaving] = useState(false);
 
+  const isChild = role === 'child';
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
@@ -90,7 +92,7 @@ const UserForm: React.FC<{
         name,
         role: role as 'admin' | 'child',
         age: age ? parseInt(age) : undefined,
-        theme: userTheme,
+        theme: isChild ? userTheme : 'default',
         avatar_url: `https://api.dicebear.com/9.x/avataaars-neutral/svg?seed=${encodeURIComponent(name)}`,
       };
       if (user) {
@@ -130,15 +132,17 @@ const UserForm: React.FC<{
             <input className={styles.input} type="number" min="1" max="99" value={age} onChange={e => setAge(e.target.value)} placeholder="Optional" />
           </div>
         </div>
-        <div className={styles.formGroup}>
-          <label className={styles.label}>Theme</label>
-          <select className={styles.input} value={userTheme} onChange={e => setUserTheme(e.target.value as Theme)}>
-            <option value="default">🌊 Classic</option>
-            <option value="quest">⚔️ Quest</option>
-            <option value="galaxy">🚀 Galaxy</option>
-            <option value="forest">🌲 Forest</option>
-          </select>
-        </div>
+        {isChild && (
+          <div className={styles.formGroup}>
+            <label className={styles.label}>Theme</label>
+            <select className={styles.input} value={userTheme} onChange={e => setUserTheme(e.target.value as Theme)}>
+              <option value="default">🌊 Classic</option>
+              <option value="quest">⚔️ Quest</option>
+              <option value="galaxy">🚀 Galaxy</option>
+              <option value="forest">🌲 Forest</option>
+            </select>
+          </div>
+        )}
       </div>
 
       <div className={styles.formActions}>

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -130,8 +130,9 @@ export const Reports: React.FC = () => {
     try {
       const resp = await api.admin.getAISummary(userId, period, date);
       setAiSummaries(prev => ({ ...prev, [userId]: resp.summary }));
-    } catch {
-      setAiSummaries(prev => ({ ...prev, [userId]: 'Failed to generate summary. AI services may not be available.' }));
+    } catch (e) {
+      const msg = e instanceof Error && e.message ? e.message : 'Failed to generate summary.';
+      setAiSummaries(prev => ({ ...prev, [userId]: msg }));
     } finally {
       setSummaryLoading(prev => ({ ...prev, [userId]: false }));
     }


### PR DESCRIPTION
## Summary

Fixes two issues:

1. **Admin theme bug** — the admin UI was picking up a kid theme (e.g. Quest) because the user form exposed a theme dropdown to admins and nothing on the client or server enforced that admins shouldn't have a theme.
2. **AI summary always fails** — the per-kid "AI Summary" button on the Reports page showed "Failed to generate summary. AI services may not be available." with no way to diagnose why, and the underlying init path gave up permanently if the AI sidecar wasn't ready within 2 minutes.

## Changes

### Admin theme
- `web/src/pages/AdminDashboard.tsx` — theme dropdown is hidden when role≠child; submit sends `theme:'default'` for admin users.
- `web/src/ThemeContext.tsx` — when `user.role === 'admin'` the theme state is forced to `default` and `setTheme()` is a no-op, regardless of any stored value.
- `internal/api/users.go` — `Update` strips the theme field for admins; `UpdateTheme` returns 403 "admin users do not have themes".
- `internal/config/loader.go` — seed config clears the theme on admin users so yaml seeding can't reintroduce the bug.
- `migrations/010_clear_admin_theme.{up,down}.sql` — one-shot cleanup for existing DBs that already have an admin with a stored theme.

### AI summary
- `cmd/server/main.go` — `initAIServices` now retries the AI endpoint health check and model pull **indefinitely** instead of giving up after 2 min. Previously a slow-to-start sidecar left the summarizer permanently `nil`, surfacing in the UI as "AI services may not be available" with no recovery short of a restart.
- `web/src/pages/Reports.tsx` — catch block now uses the real `APIError.message` so failures show the actual backend reason ("AI services not available", "no data for this user in the selected period", "AI summary generation failed: …") instead of the generic string.

## Test plan

- [x] `go test ./...` passes
- [x] End-to-end with a mock LiteRT backend: summary endpoint returns a valid summary for kid users
- [x] `PUT /users/1` with `theme:quest` on an admin is silently dropped (theme stays empty)
- [x] `PUT /users/1/theme` on an admin returns `403 {"error":"admin users do not have themes"}`
- [x] Child theme updates still work via both `PUT /users/{id}` and `PUT /users/{id}/theme`
- [x] Migration 010 verified end-to-end: seeded Alex with `theme=quest`, rolled `schema_migrations` back to 9, restarted → admin theme cleared on read
- [ ] Manual smoke test in a real deployment with litert sidecar running: click "AI Summary" on Reports page for each kid and confirm a summary is returned

## Notes

I couldn't reproduce the original summary failure without knowing the state of your runtime (was litert up? was it timing out? was something returning an error?) — with a working backend the existing code already works. The resilient-init fix covers the most likely cause (init races or gives up), and the better error surfacing in the UI means the next failure will tell you what actually went wrong instead of the generic fallback.

https://claude.ai/code/session_01HS8d7wUsHYuSW4aEcwsuGT