### PR TITLE
feat: admin can play/edit/regenerate per-chore Kokoro TTS

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -23,8 +23,10 @@ import (
 )
 
 type testEnv struct {
-	server *httptest.Server
-	db     *sql.DB
+	server  *httptest.Server
+	db      *sql.DB
+	store   *store.Store
+	chores  *api.ChoreHandler
 }
 
 func setupTest(t *testing.T) *testEnv {
@@ -54,7 +56,7 @@ func setupTest(t *testing.T) *testEnv {
 
 	s := store.New(db)
 	d := webhook.NewDispatcher(s)
-	router, _, _ := api.NewRouter(s, d)
+	router, chores, _ := api.NewRouter(s, d)
 	server := httptest.NewServer(router)
 
 	t.Cleanup(func() {
@@ -62,7 +64,7 @@ func setupTest(t *testing.T) *testEnv {
 		db.Close()
 	})
 
-	return &testEnv{server: server, db: db}
+	return &testEnv{server: server, db: db, store: s, chores: chores}
 }
 
 func (e *testEnv) request(t *testing.T, method, path string, body any, headers map[string]string) *http.Response {

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/liftedkilt/openchore/internal/ai"
@@ -1024,6 +1025,111 @@ func (h *ChoreHandler) TriggerTTSSync(w http.ResponseWriter, r *http.Request) {
 	}
 	h.ttsSyncer.Trigger()
 	writeJSON(w, http.StatusOK, map[string]any{"status": "sync triggered"})
+}
+
+// RegenerateChoreTTS re-synthesizes the TTS audio for a specific chore. The
+// admin can supply a custom spoken description; if empty, the chore's current
+// tts_description is used. The new description (if any) is persisted and the
+// chore_{id}.mp3 file is overwritten.
+func (h *ChoreHandler) RegenerateChoreTTS(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid chore id")
+		return
+	}
+
+	var req struct {
+		Description string `json:"description"`
+	}
+	// Body is optional; tolerate missing/empty bodies.
+	_ = decodeJSON(r, &req)
+
+	chore, err := h.store.GetChore(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get chore")
+		return
+	}
+	if chore == nil {
+		writeError(w, http.StatusNotFound, "chore not found")
+		return
+	}
+
+	if h.ttsGen == nil {
+		writeError(w, http.StatusServiceUnavailable, "AI services not available")
+		return
+	}
+	if !h.ttsGen.TTSAvailable() {
+		writeError(w, http.StatusServiceUnavailable, "TTS service not available")
+		return
+	}
+
+	desc := strings.TrimSpace(req.Description)
+	if desc == "" {
+		desc = chore.TTSDescription
+	}
+	if desc == "" {
+		writeError(w, http.StatusBadRequest, "no description provided and chore has no existing tts_description")
+		return
+	}
+
+	audioURL, err := h.ttsGen.SynthesizeAudio(r.Context(), desc, chore.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to synthesize audio: "+err.Error())
+		return
+	}
+	if audioURL == "" {
+		writeError(w, http.StatusServiceUnavailable, "TTS audio synthesis unavailable")
+		return
+	}
+
+	if err := h.store.UpdateChoreTTSDescription(r.Context(), chore.ID, desc); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save description")
+		return
+	}
+	if err := h.store.UpdateChoreTTSAudioURL(r.Context(), chore.ID, audioURL); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save audio URL")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"tts_description": desc,
+		"tts_audio_url":   audioURL,
+	})
+}
+
+// GenerateChoreTTSDescription uses the configured LLM to produce a fresh
+// kid-friendly spoken description for a chore. The generated text is
+// returned but NOT persisted; the admin can review and edit before saving
+// via RegenerateChoreTTS.
+func (h *ChoreHandler) GenerateChoreTTSDescription(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid chore id")
+		return
+	}
+
+	chore, err := h.store.GetChore(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get chore")
+		return
+	}
+	if chore == nil {
+		writeError(w, http.StatusNotFound, "chore not found")
+		return
+	}
+
+	if h.ttsGen == nil {
+		writeError(w, http.StatusServiceUnavailable, "AI services not available")
+		return
+	}
+
+	desc, err := h.ttsGen.GenerateDescription(r.Context(), chore.Title, chore.Description)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate description: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"description": desc})
 }
 
 // GenerateDescription lets admins generate a chore description using AI.

--- a/internal/api/chores_tts_test.go
+++ b/internal/api/chores_tts_test.go
@@ -1,0 +1,363 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/liftedkilt/openchore/internal/ai"
+	"github.com/liftedkilt/openchore/internal/aibackend"
+	"github.com/liftedkilt/openchore/internal/tts"
+)
+
+// ttsMocks wraps the two upstream services the TTSGenerator talks to so a
+// single test can assert call counts and the bodies sent to each server.
+type ttsMocks struct {
+	llm     *httptest.Server
+	tts     *httptest.Server
+	llmResp atomic.Pointer[string] // current LLM response text ("" means default)
+	llmCalls atomic.Int32
+	ttsCalls atomic.Int32
+	// lastTTSText captures the latest /v1/audio/speech "input" field value.
+	lastTTSText atomic.Pointer[string]
+}
+
+// setLLMResponse swaps out the text returned by the mocked /api/generate endpoint.
+func (m *ttsMocks) setLLMResponse(s string) {
+	m.llmResp.Store(&s)
+}
+
+// newTTSMocks spins up httptest servers for the LLM and Kokoro TTS backends,
+// enabling tests to exercise the real TTSGenerator end-to-end.
+func newTTSMocks(t *testing.T) *ttsMocks {
+	t.Helper()
+	m := &ttsMocks{}
+	defaultLLM := "Mocked spoken description."
+	m.llmResp.Store(&defaultLLM)
+
+	m.llm = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			m.llmCalls.Add(1)
+			// Drain body so the client gets a clean response.
+			io.Copy(io.Discard, r.Body)
+			resp := *m.llmResp.Load()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"model":    "mock",
+				"response": resp,
+				"done":     true,
+			})
+		case "/api/tags":
+			// /api/tags is used by the Healthy check. Return empty list.
+			_ = json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	m.tts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/audio/speech":
+			m.ttsCalls.Add(1)
+			var req struct {
+				Input string `json:"input"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			text := req.Input
+			m.lastTTSText.Store(&text)
+			w.Header().Set("Content-Type", "audio/mpeg")
+			// Tiny deterministic byte payload — content is irrelevant since we
+			// only verify that the file lands on disk.
+			_, _ = w.Write([]byte("MOCKAUDIO:" + text))
+		case "/v1/audio/voices":
+			// Used by tts.Client.Healthy for the lazy reconnect path.
+			_ = json.NewEncoder(w).Encode(map[string]any{"voices": []string{"af_heart"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	t.Cleanup(func() {
+		m.llm.Close()
+		m.tts.Close()
+	})
+	return m
+}
+
+// wireTTS attaches a real TTSGenerator (backed by newTTSMocks) to the
+// ChoreHandler under test. It also chdirs into a scratch directory so
+// chore_{id}.mp3 files don't leak into the source tree.
+func wireTTS(t *testing.T, env *testEnv, m *ttsMocks) {
+	t.Helper()
+	// Isolate the data/tts output path per test.
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(filepath.Join("data", "tts"), 0o750); err != nil {
+		t.Fatalf("mkdir data/tts: %v", err)
+	}
+
+	llmClient := aibackend.NewClient(m.llm.URL)
+	ttsClient := tts.NewClient(m.tts.URL)
+	ttsGen := ai.NewTTSGenerator(llmClient, "mock-model", ttsClient, m.tts.URL, "af_heart")
+	env.chores.SetAIServices(nil, ttsGen, nil)
+}
+
+// createChoreForTTS inserts a chore via the admin API and returns its id.
+func createChoreForTTS(t *testing.T, env *testEnv, title string) int64 {
+	t.Helper()
+	resp := env.request(t, "POST", "/api/chores", map[string]any{
+		"title":    title,
+		"category": "core",
+	}, adminHeaders())
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create chore: %d", resp.StatusCode)
+	}
+	var chore map[string]any
+	decodeBody(t, resp, &chore)
+	return int64(chore["id"].(float64))
+}
+
+// --- RegenerateChoreTTS ---
+
+func TestRegenerateTTS_HappyPath(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	choreID := createChoreForTTS(t, env, "Sweep Kitchen")
+
+	resp := env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/regenerate", choreID),
+		map[string]any{"description": "Please sweep the kitchen floor."},
+		adminHeaders(), http.StatusOK)
+
+	var body map[string]any
+	decodeBody(t, resp, &body)
+
+	if body["tts_description"] != "Please sweep the kitchen floor." {
+		t.Errorf("expected saved tts_description, got %v", body["tts_description"])
+	}
+	expectedURL := fmt.Sprintf("/tts/chore_%d.mp3", choreID)
+	if body["tts_audio_url"] != expectedURL {
+		t.Errorf("expected tts_audio_url %q, got %v", expectedURL, body["tts_audio_url"])
+	}
+
+	// DB row must reflect the new description + URL.
+	var dbDesc, dbURL string
+	err := env.db.QueryRow(`SELECT tts_description, tts_audio_url FROM chores WHERE id = ?`, choreID).
+		Scan(&dbDesc, &dbURL)
+	if err != nil {
+		t.Fatalf("query chore: %v", err)
+	}
+	if dbDesc != "Please sweep the kitchen floor." {
+		t.Errorf("db tts_description: got %q", dbDesc)
+	}
+	if dbURL != expectedURL {
+		t.Errorf("db tts_audio_url: got %q", dbURL)
+	}
+
+	// Audio file must have been written to disk with the mocked payload.
+	audioBytes, err := os.ReadFile(filepath.Join("data", "tts", fmt.Sprintf("chore_%d.mp3", choreID)))
+	if err != nil {
+		t.Fatalf("read audio file: %v", err)
+	}
+	if !strings.Contains(string(audioBytes), "Please sweep the kitchen floor.") {
+		t.Errorf("audio payload missing description text; got %q", string(audioBytes))
+	}
+
+	// The Kokoro mock should have received exactly one synthesis call; the
+	// LLM mock should NOT have been called because a description was supplied.
+	if got := m.ttsCalls.Load(); got != 1 {
+		t.Errorf("tts synth calls: want 1, got %d", got)
+	}
+	if got := m.llmCalls.Load(); got != 0 {
+		t.Errorf("llm calls: want 0 (description provided), got %d", got)
+	}
+}
+
+func TestRegenerateTTS_FallsBackToExistingDescription(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	choreID := createChoreForTTS(t, env, "Feed Cat")
+	// Seed an existing tts_description so the handler can fall back to it.
+	if _, err := env.db.Exec(`UPDATE chores SET tts_description = ? WHERE id = ?`,
+		"Feed the cat now.", choreID); err != nil {
+		t.Fatalf("seed tts_description: %v", err)
+	}
+
+	// Empty description body → handler uses the stored description.
+	resp := env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/regenerate", choreID),
+		map[string]any{"description": ""},
+		adminHeaders(), http.StatusOK)
+
+	var body map[string]any
+	decodeBody(t, resp, &body)
+	if body["tts_description"] != "Feed the cat now." {
+		t.Errorf("expected fallback tts_description, got %v", body["tts_description"])
+	}
+
+	// The Kokoro mock should have been asked to synthesize the existing text.
+	if last := m.lastTTSText.Load(); last == nil || *last != "Feed the cat now." {
+		t.Errorf("expected TTS input to be existing description, got %v", last)
+	}
+}
+
+func TestRegenerateTTS_RequiresDescriptionWhenNoneStored(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	choreID := createChoreForTTS(t, env, "Brand New Chore")
+
+	env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/regenerate", choreID),
+		map[string]any{"description": "   "}, // whitespace-only
+		adminHeaders(), http.StatusBadRequest)
+
+	if got := m.ttsCalls.Load(); got != 0 {
+		t.Errorf("tts should not be called; got %d", got)
+	}
+}
+
+func TestRegenerateTTS_RequiresAIConfiguration(t *testing.T) {
+	// No wireTTS here — ttsGen remains nil.
+	env := setupTest(t)
+	env.createAdmin(t)
+	choreID := createChoreForTTS(t, env, "Take Out Trash")
+
+	env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/regenerate", choreID),
+		map[string]any{"description": "Take out the trash."},
+		adminHeaders(), http.StatusServiceUnavailable)
+}
+
+func TestRegenerateTTS_ChoreNotFound(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	env.expectStatus(t, "POST", "/api/chores/99999/tts/regenerate",
+		map[string]any{"description": "nothing to say"},
+		adminHeaders(), http.StatusNotFound)
+}
+
+func TestRegenerateTTS_InvalidChoreID(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	env.expectStatus(t, "POST", "/api/chores/not-a-number/tts/regenerate",
+		map[string]any{"description": "x"},
+		adminHeaders(), http.StatusBadRequest)
+}
+
+func TestRegenerateTTS_NonAdminForbidden(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	choreID := createChoreForTTS(t, env, "Walk Dog")
+
+	env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/regenerate", choreID),
+		map[string]any{"description": "Walk the dog."},
+		childHeaders(kidID), http.StatusForbidden)
+
+	if got := m.ttsCalls.Load(); got != 0 {
+		t.Errorf("non-admin should not trigger TTS; got %d calls", got)
+	}
+}
+
+// --- GenerateChoreTTSDescription ---
+
+func TestGenerateTTSDescription_HappyPath(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+	m.setLLMResponse("Take out the trash to the curb.")
+
+	choreID := createChoreForTTS(t, env, "Take Out Trash")
+
+	resp := env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/generate-description", choreID),
+		nil, adminHeaders(), http.StatusOK)
+
+	var body map[string]any
+	decodeBody(t, resp, &body)
+	if body["description"] != "Take out the trash to the curb." {
+		t.Errorf("expected generated description, got %v", body["description"])
+	}
+
+	// Generation must not persist — the chore's tts_description should still be empty.
+	var stored string
+	if err := env.db.QueryRow(`SELECT tts_description FROM chores WHERE id = ?`, choreID).
+		Scan(&stored); err != nil {
+		t.Fatalf("query tts_description: %v", err)
+	}
+	if stored != "" {
+		t.Errorf("expected tts_description to remain unpersisted, got %q", stored)
+	}
+
+	// No audio file should have been written because Kokoro was not called.
+	if _, err := os.Stat(filepath.Join("data", "tts", fmt.Sprintf("chore_%d.mp3", choreID))); !os.IsNotExist(err) {
+		t.Errorf("expected no audio file, got err=%v", err)
+	}
+
+	if got := m.llmCalls.Load(); got != 1 {
+		t.Errorf("llm calls: want 1, got %d", got)
+	}
+	if got := m.ttsCalls.Load(); got != 0 {
+		t.Errorf("tts should not be called; got %d", got)
+	}
+}
+
+func TestGenerateTTSDescription_RequiresAIConfiguration(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	choreID := createChoreForTTS(t, env, "Clean Room")
+
+	env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/generate-description", choreID),
+		nil, adminHeaders(), http.StatusServiceUnavailable)
+}
+
+func TestGenerateTTSDescription_ChoreNotFound(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	env.expectStatus(t, "POST", "/api/chores/99999/tts/generate-description",
+		nil, adminHeaders(), http.StatusNotFound)
+}
+
+func TestGenerateTTSDescription_NonAdminForbidden(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	m := newTTSMocks(t)
+	wireTTS(t, env, m)
+
+	choreID := createChoreForTTS(t, env, "Make Bed")
+
+	env.expectStatus(t, "POST",
+		fmt.Sprintf("/api/chores/%d/tts/generate-description", choreID),
+		nil, childHeaders(kidID), http.StatusForbidden)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -163,6 +163,10 @@ func NewRouter(s *store.Store, dispatcher *webhook.Dispatcher) (*chi.Mux, *Chore
 				r.Post("/admin/ai/generate-description", chores.GenerateDescription)
 				r.Post("/admin/ai/suggest-points", chores.SuggestPoints)
 
+				// Per-chore TTS regeneration (admin)
+				r.Post("/chores/{id}/tts/regenerate", chores.RegenerateChoreTTS)
+				r.Post("/chores/{id}/tts/generate-description", chores.GenerateChoreTTSDescription)
+
 				// AI-powered reports
 				r.Get("/admin/reports/ai-summary", reports.GetAISummary)
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -191,6 +191,18 @@ export const api = {
       }),
     deleteSchedule: (choreId: number, scheduleId: number) =>
       fetchWithAuth(`/chores/${choreId}/schedules/${scheduleId}`, { method: 'DELETE' }),
+    regenerateTTS: (choreId: number, description?: string) =>
+      fetchWithAuth<{ tts_description: string; tts_audio_url: string }>(
+        `/chores/${choreId}/tts/regenerate`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ description: description ?? '' }),
+        },
+      ),
+    generateTTSDescription: (choreId: number) =>
+      fetchWithAuth<{ description: string }>(`/chores/${choreId}/tts/generate-description`, {
+        method: 'POST',
+      }),
   },
   points: {
     getForUser: (userId: number) => fetchWithAuth<PointsData>(`/users/${userId}/points`),

--- a/web/src/components/EditChoreModal/EditChoreModal.module.css
+++ b/web/src/components/EditChoreModal/EditChoreModal.module.css
@@ -92,3 +92,73 @@
   color: var(--status-required);
   font-size: 0.8rem;
 }
+
+/* Secondary button for TTS section */
+.btnSecondary {
+  composes: btnPrimary from '../../styles/forms.module.css';
+  padding: 0.6rem 1rem;
+  min-height: 44px;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary, #e2e8f0);
+}
+
+.btnSecondary:hover {
+  background: rgba(255, 255, 255, 0.14);
+  opacity: 1;
+}
+
+/* Textarea used for the TTS spoken description */
+.textarea {
+  composes: input from '../../styles/forms.module.css';
+  padding: 0.65rem 0.85rem;
+  font-size: 0.85rem;
+  resize: vertical;
+  min-height: 80px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+/* TTS audio player row */
+.ttsPlayerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.ttsPlayBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-blue, #38bdf8);
+  color: var(--bg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.ttsPlayBtn:hover {
+  opacity: 0.9;
+}
+
+.ttsHint {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+/* Spinner animation for the regenerate button */
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}

--- a/web/src/components/EditChoreModal/EditChoreModal.tsx
+++ b/web/src/components/EditChoreModal/EditChoreModal.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { Save, Check } from 'lucide-react';
+import React, { useState, useRef, useEffect } from 'react';
+import { Save, Check, Play, Pause, RefreshCw, Sparkles } from 'lucide-react';
 import Modal from '../Modal/Modal';
-import { api } from '../../api';
+import { api, APIError } from '../../api';
 import type { Chore, User } from '../../types';
 import styles from './EditChoreModal.module.css';
 
@@ -31,6 +31,79 @@ const EditChoreModal: React.FC<Props> = ({ chore, isOpen, onClose, onSaved, user
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
+
+  // TTS editing state
+  const [ttsDescription, setTtsDescription] = useState(chore.tts_description || '');
+  const [ttsAudioURL, setTtsAudioURL] = useState(chore.tts_audio_url || '');
+  const [ttsCacheBust, setTtsCacheBust] = useState(() => Date.now());
+  const [ttsRegenerating, setTtsRegenerating] = useState(false);
+  const [ttsGenerating, setTtsGenerating] = useState(false);
+  const [ttsSaved, setTtsSaved] = useState(false);
+  const [ttsError, setTtsError] = useState('');
+  const [ttsPlaying, setTtsPlaying] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const handleEnded = () => setTtsPlaying(false);
+    const handlePause = () => setTtsPlaying(false);
+    const handlePlay = () => setTtsPlaying(true);
+    audio.addEventListener('ended', handleEnded);
+    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('play', handlePlay);
+    return () => {
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('play', handlePlay);
+    };
+  }, [ttsAudioURL]);
+
+  const audioSrc = ttsAudioURL ? `${ttsAudioURL}?v=${ttsCacheBust}` : '';
+
+  const handlePlayPause = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      audio.play().catch(() => {
+        setTtsError('Unable to play audio');
+      });
+    } else {
+      audio.pause();
+    }
+  };
+
+  const handleRegenerateTTS = async () => {
+    setTtsRegenerating(true);
+    setTtsError('');
+    setTtsSaved(false);
+    try {
+      const resp = await api.chores.regenerateTTS(chore.id, ttsDescription.trim());
+      setTtsDescription(resp.tts_description);
+      setTtsAudioURL(resp.tts_audio_url);
+      setTtsCacheBust(Date.now());
+      setTtsSaved(true);
+      onSaved();
+      setTimeout(() => setTtsSaved(false), 2000);
+    } catch (e) {
+      const msg = e instanceof APIError ? (e.data?.error || e.message) : (e instanceof Error ? e.message : 'Failed to regenerate TTS');
+      setTtsError(msg);
+    }
+    setTtsRegenerating(false);
+  };
+
+  const handleGenerateTTSDescription = async () => {
+    setTtsGenerating(true);
+    setTtsError('');
+    try {
+      const resp = await api.chores.generateTTSDescription(chore.id);
+      setTtsDescription(resp.description);
+    } catch (e) {
+      const msg = e instanceof APIError ? (e.data?.error || e.message) : (e instanceof Error ? e.message : 'Failed to generate description');
+      setTtsError(msg);
+    }
+    setTtsGenerating(false);
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -129,6 +202,71 @@ const EditChoreModal: React.FC<Props> = ({ chore, isOpen, onClose, onSaved, user
             {error && <span className={styles.error}>{error}</span>}
             <button className={styles.btnPrimary} onClick={handleSave} disabled={saving || !title.trim()}>
               <Save size={14} /> {saving ? 'Saving...' : 'Save Details'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <hr className={styles.divider} />
+
+      {/* --- TTS Audio --- */}
+      <div className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionTitle}>Kokoro TTS</span>
+        </div>
+        <div className={styles.formGrid}>
+          {ttsAudioURL ? (
+            <div className={styles.ttsPlayerRow}>
+              <button
+                type="button"
+                className={styles.ttsPlayBtn}
+                onClick={handlePlayPause}
+                aria-label={ttsPlaying ? 'Pause TTS audio' : 'Play TTS audio'}
+                title={ttsPlaying ? 'Pause' : 'Play'}
+              >
+                {ttsPlaying ? <Pause size={18} /> : <Play size={18} />}
+              </button>
+              <audio ref={audioRef} src={audioSrc} preload="none" />
+              <span className={styles.ttsHint}>
+                {ttsPlaying ? 'Playing…' : 'Click to preview generated audio'}
+              </span>
+            </div>
+          ) : (
+            <div className={styles.ttsHint}>No TTS audio has been generated for this chore yet.</div>
+          )}
+
+          <div className={styles.formGroup}>
+            <label className={styles.label}>Spoken description (TTS prompt)</label>
+            <textarea
+              className={styles.textarea}
+              value={ttsDescription}
+              onChange={e => setTtsDescription(e.target.value)}
+              placeholder="What should the TTS voice say for this chore?"
+              rows={3}
+            />
+          </div>
+
+          <div className={styles.saveRow}>
+            {ttsSaved && <span className={styles.saved}><Check size={14} /> Regenerated</span>}
+            {ttsError && <span className={styles.error}>{ttsError}</span>}
+            <button
+              type="button"
+              className={styles.btnSecondary}
+              onClick={handleGenerateTTSDescription}
+              disabled={ttsGenerating || ttsRegenerating}
+              title="Generate a new spoken description with AI"
+            >
+              <Sparkles size={14} /> {ttsGenerating ? 'Generating…' : 'Suggest Text'}
+            </button>
+            <button
+              type="button"
+              className={styles.btnPrimary}
+              onClick={handleRegenerateTTS}
+              disabled={ttsRegenerating || ttsGenerating || !ttsDescription.trim()}
+            >
+              <RefreshCw size={14} className={ttsRegenerating ? styles.spin : ''} />
+              {' '}
+              {ttsRegenerating ? 'Regenerating…' : 'Save & Regenerate Audio'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Add a Kokoro TTS section to the admin Edit Chore modal so admins can
audition the generated audio, tweak the spoken prompt, and re-synthesize
without waiting for the background TTS sync.

Backend:
- POST /api/chores/{id}/tts/regenerate saves a custom tts_description and
  re-synthesizes chore_{id}.mp3 via the configured Kokoro endpoint.
- POST /api/chores/{id}/tts/generate-description returns a fresh LLM-
  generated spoken description without persisting it, so admins can
  review before saving.

Frontend:
- Inline HTML5 audio player with play/pause inside EditChoreModal.
- Editable textarea pre-filled with the current tts_description.
- Suggest Text button (LLM) and Save & Regenerate Audio button.
- Cache-busts the audio URL client-side so regenerated files play
  immediately without stale browser caching.