### PR TITLE
fix(litert): drop unsupported max_tokens kwarg in create_conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ config/config.yaml
 # OS
 .DS_Store
 
+# Python build artifacts
+__pycache__/
+*.pyc
+
 # Runtime data (uploads, TTS audio, profiling)
 data/
 default.profraw

--- a/litert/server.py
+++ b/litert/server.py
@@ -71,7 +71,11 @@ class Handler(BaseHTTPRequestHandler):
             start = time.time()
             tmp_files = []
 
-            with eng.create_conversation(max_tokens=max_tokens) as conv:
+            # Note: newer litert_lm.Engine.create_conversation() no longer
+            # accepts max_tokens as a kwarg — the supported parameters are
+            # messages, tools, tool_event_handler, extra_context. We still
+            # log the client's requested max_tokens for observability.
+            with eng.create_conversation() as conv:
                 response = None
                 for msg in messages:
                     role = msg.get("role", "user")
@@ -132,7 +136,9 @@ class Handler(BaseHTTPRequestHandler):
             eng = get_engine()
             start = time.time()
 
-            with eng.create_conversation(max_tokens=max_tokens) as conv:
+            # See note in _handle_chat: create_conversation() no longer
+            # accepts max_tokens in the current litert_lm API.
+            with eng.create_conversation() as conv:
                 response = conv.send_message({
                     "role": "user",
                     "content": [{"type": "text", "text": prompt}],


### PR DESCRIPTION
## Summary

- Fix the LiteRT wrapper crashing any LLM call with `create_conversation(): incompatible function arguments ... kwargs = { max_tokens: int }`. The current `litert_lm.Engine.create_conversation()` only accepts `messages / tools / tool_event_handler / extra_context`, so passing `max_tokens=...` raises `TypeError` and surfaces as a 500 in the admin UI — most visibly on the chore editor's **Suggest Text** button, but also on chore description generation, the TTS description sync, and AI photo review feedback. The warmup at the bottom of the module already calls `create_conversation()` with no args, which is why startup still worked.
- Drop the unsupported kwarg from both `_handle_chat` and `_handle_generate`. The client-supplied `num_predict` is still parsed and logged so we can see what was requested; re-enforcing a token cap will need to come from whatever replaces it in the current LiteRT API.
- Add `__pycache__/` and `*.pyc` to `.gitignore` so running `python3 -m py_compile litert/server.py` (or just importing it) doesn't leave stray untracked files in the working tree.

## Test plan

- [x] `python3 -m py_compile litert/server.py`
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Restart LiteRT container and click **Suggest Text** in the chore editor — should return a generated spoken description instead of a 500
- [ ] Confirm chore creation still auto-generates a TTS description in the background
- [ ] Confirm the existing TTS sync loop still runs cleanly

https://claude.ai/code/session_01Ax7cwL4k9mRk2EGCRx1Qpy