### PR TITLE
fix: require current PIN when admin changes their own PIN

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3317,3 +3317,38 @@ func TestProfilePinCannotBeChangedByOtherChild(t *testing.T) {
 	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/users/%d/pin", kidA),
 		nil, childHeaders(kidB), http.StatusForbidden)
 }
+
+// Admin changing their *own* PIN must still supply the current value — the
+// admin override only exists for resetting another user's forgotten PIN.
+func TestProfilePinAdminMustVerifyOwnCurrentPin(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+
+	// Admin sets their own initial PIN. No current_pin required because none exists yet.
+	env.expectStatus(t, "PUT", "/api/users/1/pin",
+		map[string]any{"new_pin": "1234"}, adminHeaders(), http.StatusOK)
+
+	// Wrong current_pin must be rejected even though caller is admin.
+	env.expectStatus(t, "PUT", "/api/users/1/pin",
+		map[string]any{"current_pin": "9999", "new_pin": "5678"}, adminHeaders(), http.StatusUnauthorized)
+
+	// Empty current_pin must also be rejected.
+	env.expectStatus(t, "PUT", "/api/users/1/pin",
+		map[string]any{"new_pin": "5678"}, adminHeaders(), http.StatusUnauthorized)
+
+	// Correct current_pin succeeds.
+	env.expectStatus(t, "PUT", "/api/users/1/pin",
+		map[string]any{"current_pin": "1234", "new_pin": "5678"}, adminHeaders(), http.StatusOK)
+
+	// Old PIN no longer verifies.
+	env.expectStatus(t, "POST", "/api/users/1/verify-pin",
+		map[string]any{"pin": "1234"}, nil, http.StatusUnauthorized)
+
+	// Clearing own PIN with the wrong current value is rejected.
+	env.expectStatus(t, "DELETE", "/api/users/1/pin",
+		map[string]any{"current_pin": "0000"}, adminHeaders(), http.StatusUnauthorized)
+
+	// Clearing with the right current value succeeds.
+	env.expectStatus(t, "DELETE", "/api/users/1/pin",
+		map[string]any{"current_pin": "5678"}, adminHeaders(), http.StatusOK)
+}

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -411,9 +411,10 @@ type setPinRequest struct {
 	NewPin     string `json:"new_pin"`
 }
 
-// SetPin sets or updates a user's profile PIN. A user may only change their
-// own PIN, and must supply the current PIN if one is already set. Admins can
-// set/reset any user's PIN without the current value.
+// SetPin sets or updates a user's profile PIN. A user changing their own PIN
+// (whether admin or child) must supply the current PIN if one is already set.
+// Admins can reset another user's PIN without supplying the current value
+// (used for forgotten-PIN recovery from the admin dashboard).
 func (h *UserHandler) SetPin(w http.ResponseWriter, r *http.Request) {
 	id, err := urlParamInt64(r, "id")
 	if err != nil {
@@ -427,10 +428,14 @@ func (h *UserHandler) SetPin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := caller.Role == "admin"
-	if !isAdmin && caller.ID != id {
+	targetIsSelf := caller.ID == id
+	if !isAdmin && !targetIsSelf {
 		writeError(w, http.StatusForbidden, "can only change your own pin")
 		return
 	}
+	// Only an admin acting on a *different* user may bypass the current-PIN
+	// check. An admin changing their own PIN must still prove they know it.
+	adminOverride := isAdmin && !targetIsSelf
 
 	var req setPinRequest
 	if err := decodeJSON(r, &req); err != nil {
@@ -458,8 +463,8 @@ func (h *UserHandler) SetPin(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "user not found")
 			return
 		}
-	} else if !isAdmin {
-		// Non-admin changing their own PIN must supply the current value.
+	} else if !adminOverride {
+		// Caller is changing their own PIN — must supply the current value.
 		if err := bcrypt.CompareHashAndPassword([]byte(existingHash), []byte(req.CurrentPin)); err != nil {
 			writeError(w, http.StatusUnauthorized, "incorrect current pin")
 			return
@@ -482,8 +487,10 @@ type clearPinRequest struct {
 	CurrentPin string `json:"current_pin"`
 }
 
-// ClearPin removes the PIN from a user's profile. Non-admin callers must
-// supply the current PIN; admins can clear any user's PIN without it.
+// ClearPin removes the PIN from a user's profile. A user clearing their own
+// PIN (whether admin or child) must supply the current value. Admins clearing
+// another user's PIN can do so without it (used to reset a forgotten kid PIN
+// from the admin dashboard).
 func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 	id, err := urlParamInt64(r, "id")
 	if err != nil {
@@ -497,10 +504,12 @@ func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := caller.Role == "admin"
-	if !isAdmin && caller.ID != id {
+	targetIsSelf := caller.ID == id
+	if !isAdmin && !targetIsSelf {
 		writeError(w, http.StatusForbidden, "can only change your own pin")
 		return
 	}
+	adminOverride := isAdmin && !targetIsSelf
 
 	existingHash, err := h.store.GetUserPinHash(r.Context(), id)
 	if err != nil {
@@ -513,7 +522,7 @@ func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isAdmin {
+	if !adminOverride {
 		var req clearPinRequest
 		if err := decodeJSON(r, &req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid request body")


### PR DESCRIPTION
## Summary

Follow-up to the profile PIN feature. The admin override that lets parents reset a kid's forgotten PIN was applied to *any* admin caller — including an admin changing their own PIN through the dashboard's PIN settings modal. The modal would prompt for the current PIN, accept any garbage value, and silently change or clear the PIN anyway.

The override now only fires when the admin is acting on a *different* user (`caller.ID != id`). When admin and target are the same user, the current-PIN check applies just like it does for kids. The legitimate cross-user "admin resets a kid's forgotten PIN" path used by AdminDashboard's reset button is unchanged.

## Changes

- `internal/api/users.go` — `SetPin` and `ClearPin` now compute `adminOverride := isAdmin && !targetIsSelf` and gate the bypass on that instead of plain `isAdmin`.
- `internal/api/api_test.go` — new `TestProfilePinAdminMustVerifyOwnCurrentPin` exercises the admin self-change/self-clear path with wrong, missing, and correct current PINs across both `PUT` and `DELETE`.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `TestProfilePinAdminMustVerifyOwnCurrentPin` — new regression test passes
- [x] `TestProfilePinSetVerifyAndClear` — pre-existing test still verifies the legitimate cross-user admin reset path

https://claude.ai/code/session_01JyshHZadWLdZ2ABSNVzSDe