### PR TITLE
fix: prevent false points decay and normalize date display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Binaries
 /openchore
+/server
 /cmd/server/server
 
 # Frontend

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -440,8 +440,13 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 	}
 	if existing != nil {
 		if existing.Status == model.StatusAIRejected {
-			// Allow retry — delete the rejected attempt
-			_ = h.store.UncompleteChore(r.Context(), scheduleID, req.CompletionDate)
+			// Allow retry — delete the rejected attempt so we don't end up
+			// with duplicate rows (one ai_rejected + one approved) which
+			// confuses the points-decay checker.
+			if err := h.store.UncompleteChore(r.Context(), scheduleID, req.CompletionDate); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to clear previous attempt")
+				return
+			}
 		} else {
 			writeError(w, http.StatusConflict, "chore already completed for this date")
 			return

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -234,7 +234,17 @@ func (s *Store) GetScheduledChoresForUser(ctx context.Context, userID int64, dat
 			 LIMIT 1) as completed_by_sibling_name
 		FROM chore_schedules cs
 		JOIN chores c ON c.id = cs.chore_id
-		LEFT JOIN chore_completions cc ON cc.chore_schedule_id = cs.id AND cc.completion_date = ?
+		LEFT JOIN chore_completions cc ON cc.id = (
+				SELECT cc3.id FROM chore_completions cc3
+				WHERE cc3.chore_schedule_id = cs.id AND cc3.completion_date = ?
+				ORDER BY CASE cc3.status
+					WHEN 'approved' THEN 1
+					WHEN 'pending'  THEN 2
+					WHEN 'rejected' THEN 3
+					WHEN 'ai_rejected' THEN 4
+				END
+				LIMIT 1
+			)
 		WHERE cs.assigned_to = ?
 		  AND (
 			(cs.day_of_week = ? AND cs.specific_date IS NULL AND cs.recurrence_interval IS NULL)
@@ -1153,11 +1163,12 @@ func (s *Store) DebitExpiryPenalty(ctx context.Context, userID, completionID int
 	return err
 }
 
-func (s *Store) DebitDecay(ctx context.Context, userID int64, amount int) error {
+func (s *Store) DebitDecay(ctx context.Context, userID int64, amount int, date string) error {
+	key := fmt.Sprintf("points_decay:%d:%s", userID, date)
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO point_transactions (user_id, amount, reason, note)
-		 VALUES (?, ?, ?, 'Daily points decay')`,
-		userID, -amount, model.ReasonPointsDecay)
+		`INSERT INTO point_transactions (user_id, amount, reason, note, idempotency_key)
+		 VALUES (?, ?, ?, 'Daily points decay', ?)`,
+		userID, -amount, model.ReasonPointsDecay, key)
 	return err
 }
 
@@ -1664,7 +1675,12 @@ func (s *Store) GetExpiredChores(ctx context.Context, date string, currentTime s
 		FROM chore_schedules cs
 		JOIN chores c ON c.id = cs.chore_id
 		JOIN users u ON u.id = cs.assigned_to
-		LEFT JOIN chore_completions cc ON cc.chore_schedule_id = cs.id AND cc.completion_date = ?
+		LEFT JOIN chore_completions cc ON cc.id = (
+				SELECT cc3.id FROM chore_completions cc3
+				WHERE cc3.chore_schedule_id = cs.id AND cc3.completion_date = ?
+				  AND cc3.status != 'ai_rejected'
+				LIMIT 1
+			)
 		WHERE u.paused = 0
 		  AND cs.due_by IS NOT NULL
 		  AND cs.due_by != ''

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,6 +14,15 @@ type Store struct {
 	db *sql.DB
 }
 
+// normalizeDate strips the time component that modernc.org/sqlite appends
+// when scanning DATE columns (e.g. "2026-04-11T00:00:00Z" → "2026-04-11").
+func normalizeDate(s string) string {
+	if len(s) > 10 && (s[10] == 'T' || s[10] == ' ') {
+		return s[:10]
+	}
+	return s
+}
+
 func boolToInt(b bool) int {
 	if b {
 		return 1
@@ -385,6 +394,7 @@ func (s *Store) GetCompletionForScheduleDate(ctx context.Context, scheduleID int
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
+	cc.CompletionDate = normalizeDate(cc.CompletionDate)
 	return cc, err
 }
 
@@ -397,6 +407,7 @@ func (s *Store) GetCompletion(ctx context.Context, id int64) (*model.ChoreComple
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
+	cc.CompletionDate = normalizeDate(cc.CompletionDate)
 	return cc, err
 }
 
@@ -429,6 +440,7 @@ func (s *Store) ListPendingCompletions(ctx context.Context) ([]PendingCompletion
 		if err := rows.Scan(&p.ID, &p.ChoreTitle, &p.ChildName, &p.PhotoURL, &p.CompletionDate, &p.CompletedAt); err != nil {
 			return nil, err
 		}
+		p.CompletionDate = normalizeDate(p.CompletionDate)
 		pending = append(pending, p)
 	}
 	return pending, rows.Err()
@@ -1866,6 +1878,7 @@ func (s *Store) ReportCompletionTrend(ctx context.Context, startDate, endDate st
 		if err := rows.Scan(&r.Date, &r.Completed, &r.Assigned); err != nil {
 			return nil, err
 		}
+		r.Date = normalizeDate(r.Date)
 		results = append(results, r)
 	}
 	return results, rows.Err()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1163,12 +1163,12 @@ func (s *Store) DebitExpiryPenalty(ctx context.Context, userID, completionID int
 	return err
 }
 
-func (s *Store) DebitDecay(ctx context.Context, userID int64, amount int, date string) error {
+func (s *Store) DebitDecay(ctx context.Context, userID int64, amount int, date, note string) error {
 	key := fmt.Sprintf("points_decay:%d:%s", userID, date)
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO point_transactions (user_id, amount, reason, note, idempotency_key)
-		 VALUES (?, ?, ?, 'Daily points decay', ?)`,
-		userID, -amount, model.ReasonPointsDecay, key)
+		 VALUES (?, ?, ?, ?, ?)`,
+		userID, -amount, model.ReasonPointsDecay, note, key)
 	return err
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1293,7 +1293,7 @@ func TestDebitDecay(t *testing.T) {
 	u := createTestUser(t, s, "Child", "child")
 	s.AdminAdjustPoints(ctx, u.ID, 100, "")
 
-	err := s.DebitDecay(ctx, u.ID, 5, "2026-04-11")
+	err := s.DebitDecay(ctx, u.ID, 5, "2026-04-11", "Points decay for 2026-04-11 — missed: Test")
 	if err != nil {
 		t.Fatalf("DebitDecay: %v", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1293,7 +1293,7 @@ func TestDebitDecay(t *testing.T) {
 	u := createTestUser(t, s, "Child", "child")
 	s.AdminAdjustPoints(ctx, u.ID, 100, "")
 
-	err := s.DebitDecay(ctx, u.ID, 5)
+	err := s.DebitDecay(ctx, u.ID, 5, "2026-04-11")
 	if err != nil {
 		t.Fatalf("DebitDecay: %v", err)
 	}

--- a/internal/webhook/decay.go
+++ b/internal/webhook/decay.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/liftedkilt/openchore/internal/model"
@@ -117,18 +118,26 @@ func (pdc *PointsDecayChecker) check(ctx context.Context) {
 		}
 
 		if debit > 0 {
-			if err := pdc.store.DebitDecay(ctx, cfg.UserID, debit); err != nil {
-				log.Printf("points-decay: failed to debit user %d: %v", cfg.UserID, err)
-				continue
-			}
-			log.Printf("points-decay: debited %d points from user %d (%s) for missed chores on %s", debit, user.ID, user.Name, yesterday)
+			if err := pdc.store.DebitDecay(ctx, cfg.UserID, debit, yesterday); err != nil {
+				// If the idempotency key rejects the insert, this date was
+				// already debited — fall through to update last_decay_at so
+				// we don't keep retrying.
+				if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+					log.Printf("points-decay: already debited user %d for %s (idempotency), advancing timer", cfg.UserID, yesterday)
+				} else {
+					log.Printf("points-decay: failed to debit user %d: %v", cfg.UserID, err)
+					continue
+				}
+			} else {
+				log.Printf("points-decay: debited %d points from user %d (%s) for missed chores on %s", debit, user.ID, user.Name, yesterday)
 
-			pdc.dispatcher.Fire(EventPointsDecayed, map[string]any{
-				"user_id":   user.ID,
-				"user_name": user.Name,
-				"amount":    debit,
-				"date":      yesterday,
-			})
+				pdc.dispatcher.Fire(EventPointsDecayed, map[string]any{
+					"user_id":   user.ID,
+					"user_name": user.Name,
+					"amount":    debit,
+					"date":      yesterday,
+				})
+			}
 		}
 
 		if err := pdc.store.UpdateLastDecayAt(ctx, cfg.UserID, now); err != nil {

--- a/internal/webhook/decay.go
+++ b/internal/webhook/decay.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -86,20 +87,20 @@ func (pdc *PointsDecayChecker) check(ctx context.Context) {
 		}
 
 		nonBonusCount := 0
-		missedAny := false
+		var missedTitles []string
 		for _, c := range chores {
 			if c.Category == model.CategoryBonus {
 				continue
 			}
 			nonBonusCount++
 			if !c.Completed {
-				missedAny = true
+				missedTitles = append(missedTitles, c.Title)
 			}
 		}
 
 		// No non-bonus chores scheduled or everything was completed: no
 		// decay, but still advance the timer so we don't keep re-checking.
-		if nonBonusCount == 0 || !missedAny {
+		if nonBonusCount == 0 || len(missedTitles) == 0 {
 			if err := pdc.store.UpdateLastDecayAt(ctx, cfg.UserID, now); err != nil {
 				log.Printf("points-decay: failed to update last_decay_at for user %d: %v", cfg.UserID, err)
 			}
@@ -118,7 +119,8 @@ func (pdc *PointsDecayChecker) check(ctx context.Context) {
 		}
 
 		if debit > 0 {
-			if err := pdc.store.DebitDecay(ctx, cfg.UserID, debit, yesterday); err != nil {
+			note := fmt.Sprintf("Points decay for %s — missed: %s", yesterday, strings.Join(missedTitles, ", "))
+			if err := pdc.store.DebitDecay(ctx, cfg.UserID, debit, yesterday, note); err != nil {
 				// If the idempotency key rejects the insert, this date was
 				// already debited — fall through to update last_decay_at so
 				// we don't keep retrying.
@@ -129,13 +131,15 @@ func (pdc *PointsDecayChecker) check(ctx context.Context) {
 					continue
 				}
 			} else {
-				log.Printf("points-decay: debited %d points from user %d (%s) for missed chores on %s", debit, user.ID, user.Name, yesterday)
+				log.Printf("points-decay: debited %d points from user %d (%s) for missed chores on %s (missed: %s)",
+					debit, user.ID, user.Name, yesterday, strings.Join(missedTitles, ", "))
 
 				pdc.dispatcher.Fire(EventPointsDecayed, map[string]any{
-					"user_id":   user.ID,
-					"user_name": user.Name,
-					"amount":    debit,
-					"date":      yesterday,
+					"user_id":    user.ID,
+					"user_name":  user.Name,
+					"amount":     debit,
+					"date":       yesterday,
+					"missed":     missedTitles,
 				})
 			}
 		}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1103,3 +1103,154 @@ func TestPointsDecayChecker_ClampsToNonNegativeBalance(t *testing.T) {
 		t.Errorf("expected balance clamped to 0, got %d", balance)
 	}
 }
+
+// TestPointsDecayChecker_NoDecayWithDuplicateCompletions verifies that decay
+// is NOT applied when a chore has both an ai_rejected and an approved
+// completion record (duplicate rows). This can happen when the
+// UncompleteChore call during an AI-rejection retry fails silently.
+func TestPointsDecayChecker_NoDecayWithDuplicateCompletions(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	_, scheduleID := createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	// Simulate the duplicate-completion scenario: an ai_rejected record
+	// that was not cleaned up, plus a subsequent approved record.
+	if err := env.store.CompleteChore(ctx, &model.ChoreCompletion{
+		ChoreScheduleID: scheduleID,
+		CompletedBy:     childID,
+		Status:          model.StatusAIRejected,
+		CompletionDate:  yesterday.Format(model.DateFormat),
+		AIFeedback:      "Doesn't look complete",
+		AIConfidence:    0.9,
+	}); err != nil {
+		t.Fatalf("CompleteChore (ai_rejected): %v", err)
+	}
+	if err := env.store.CompleteChore(ctx, &model.ChoreCompletion{
+		ChoreScheduleID: scheduleID,
+		CompletedBy:     childID,
+		Status:          model.StatusApproved,
+		CompletionDate:  yesterday.Format(model.DateFormat),
+	}); err != nil {
+		t.Fatalf("CompleteChore (approved): %v", err)
+	}
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 10, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 100 {
+		t.Errorf("expected balance to stay 100 (no decay with duplicate completions), got %d", balance)
+	}
+}
+
+// TestPointsDecayChecker_MultipleKidsAllComplete verifies that when multiple
+// kids each have several non-bonus chores all completed, no decay is applied
+// to any of them.
+func TestPointsDecayChecker_MultipleKidsAllComplete(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	kids := make([]int64, 3)
+	for i := range kids {
+		kids[i] = createChildUser(t, env, fmt.Sprintf("Kid%d", i))
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	dow := int(yesterday.Weekday())
+	dateStr := yesterday.Format(model.DateFormat)
+
+	// Each kid gets 3 non-bonus chores (required + core) and 1 bonus.
+	for _, kidID := range kids {
+		if err := env.store.AdminAdjustPoints(ctx, kidID, 100, ""); err != nil {
+			t.Fatalf("AdminAdjustPoints: %v", err)
+		}
+
+		for _, cat := range []string{"required", "required", "core", "bonus"} {
+			_, schedID := createChoreWithSchedule(t, env, parentID, kidID, cat, dow, nil, 0)
+			// Complete all chores including the bonus one.
+			if err := env.store.CompleteChore(ctx, &model.ChoreCompletion{
+				ChoreScheduleID: schedID,
+				CompletedBy:     kidID,
+				Status:          model.StatusApproved,
+				CompletionDate:  dateStr,
+			}); err != nil {
+				t.Fatalf("CompleteChore: %v", err)
+			}
+		}
+
+		if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+			UserID: kidID, Enabled: true, DecayRate: 10, DecayIntervalHours: 24,
+		}); err != nil {
+			t.Fatalf("SetUserDecayConfig: %v", err)
+		}
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	for i, kidID := range kids {
+		balance, _ := env.store.GetPointBalance(ctx, kidID)
+		if balance != 100 {
+			t.Errorf("Kid%d: expected balance 100 (no decay), got %d", i, balance)
+		}
+	}
+}
+
+// TestPointsDecayChecker_IdempotentDebit verifies that running the decay
+// checker twice for the same date does not double-debit, thanks to the
+// idempotency key on point_transactions.
+func TestPointsDecayChecker_IdempotentDebit(t *testing.T) {
+	env := setupTest(t)
+	ctx := context.Background()
+
+	parentID := createParentUser(t, env, "Parent")
+	childID := createChildUser(t, env, "Child")
+
+	if err := env.store.AdminAdjustPoints(ctx, childID, 100, ""); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	createChoreWithSchedule(t, env, parentID, childID, "required", int(yesterday.Weekday()), nil, 0)
+
+	if err := env.store.SetUserDecayConfig(ctx, &model.UserDecayConfig{
+		UserID: childID, Enabled: true, DecayRate: 10, DecayIntervalHours: 24,
+	}); err != nil {
+		t.Fatalf("SetUserDecayConfig: %v", err)
+	}
+
+	pdc := NewPointsDecayChecker(env.store, env.dispatcher)
+	pdc.check(ctx)
+
+	balance, _ := env.store.GetPointBalance(ctx, childID)
+	if balance != 90 {
+		t.Fatalf("expected balance 90 after first decay, got %d", balance)
+	}
+
+	// Manually reset last_decay_at to simulate UpdateLastDecayAt failing
+	// after the debit succeeded, so the checker would try again.
+	env.db.ExecContext(ctx, `UPDATE user_decay_config SET last_decay_at = NULL WHERE user_id = ?`, childID)
+
+	pdc.check(ctx)
+
+	balance, _ = env.store.GetPointBalance(ctx, childID)
+	if balance != 90 {
+		t.Errorf("expected balance to remain 90 (idempotent), got %d", balance)
+	}
+}

--- a/web/src/components/admin/ActivityTab.tsx
+++ b/web/src/components/admin/ActivityTab.tsx
@@ -61,6 +61,7 @@ export const ActivityTab: React.FC = () => {
       case 'admin_adjust': return 'Admin adjustment';
       case 'expiry_penalty': return 'Late penalty';
       case 'points_decay': return 'Points decay';
+      case 'missed_chore': return 'Missed chore penalty';
       default: return reason;
     }
   };

--- a/web/src/components/admin/ApprovalsTab.tsx
+++ b/web/src/components/admin/ApprovalsTab.tsx
@@ -51,7 +51,7 @@ export const ApprovalsTab: React.FC<{ onCountChange: (count: number) => void }> 
             <div className={styles.approvalInfo}>
               <div className={styles.approvalHeader}>
                 <span className={styles.approvalUser}>{p.child_name}</span>
-                <span className={styles.approvalDate}>{p.completion_date}</span>
+                <span className={styles.approvalDate}>{new Date(p.completion_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
               </div>
               <h3 className={styles.approvalTitle}>{p.chore_title}</h3>
               {p.photo_url && (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -245,7 +245,7 @@ export interface PointTransaction {
   id: number;
   user_id: number;
   amount: number;
-  reason: 'chore_complete' | 'chore_uncomplete' | 'reward_redeem' | 'streak_bonus' | 'admin_adjust' | 'expiry_penalty' | 'points_decay';
+  reason: 'chore_complete' | 'chore_uncomplete' | 'reward_redeem' | 'streak_bonus' | 'admin_adjust' | 'expiry_penalty' | 'points_decay' | 'missed_chore';
   reference_id?: number;
   note?: string;
   created_at: string;


### PR DESCRIPTION
## Summary

- **Fix false points decay**: The decay checker could apply decay even when all chores were completed, due to duplicate `chore_completions` rows (e.g. an `ai_rejected` + `approved` pair from a failed cleanup) causing the LEFT JOIN to return multiple rows — the `ai_rejected` row made the chore appear incomplete.
- **Add idempotency to decay debits**: `DebitDecay` now uses an idempotency key (`points_decay:{userId}:{date}`) so a crash between debiting and updating `last_decay_at` can never cause a double-debit.
- **Fix approval date display**: The approvals tab showed raw ISO timestamps like `2026-04-12T00:00:00Z` because `modernc.org/sqlite` normalizes DATE columns on read. Backend now strips the time suffix; frontend formats as a human-readable date.

### Decay fix details

1. Changed the `LEFT JOIN` in `GetScheduledChoresForUser` to a correlated subquery that picks the single best completion per schedule (prioritizing `approved > pending > rejected > ai_rejected`), so duplicate rows never surface.
2. Stopped swallowing the `UncompleteChore` error in the AI-rejection retry path — the silent failure was the root cause of duplicate rows.
3. Added idempotency key to `DebitDecay` backed by the existing UNIQUE partial index on `point_transactions.idempotency_key`.

### 5-point decay on a 10-point setting

The balance is clamped: `debit = min(decayRate, currentBalance)`. That child had only 5 points. This is working as designed.

## Test plan

- [x] New test: `TestPointsDecayChecker_NoDecayWithDuplicateCompletions` — verifies no decay when both `ai_rejected` and `approved` completions exist for the same schedule
- [x] New test: `TestPointsDecayChecker_MultipleKidsAllComplete` — three kids, multiple chore types, all completed → no decay for any
- [x] New test: `TestPointsDecayChecker_IdempotentDebit` — verifies double-run after `last_decay_at` reset does not double-debit
- [x] All existing tests pass (`go test ./internal/...`)
- [x] Full build passes (`CGO_ENABLED=0 go build ./cmd/...`)
- [ ] Verify approvals tab shows clean dates (e.g. "Apr 12") instead of ISO timestamps

https://claude.ai/code/session_01GPsBEB9YbBbNSZsrEUv4aA