### PR TITLE
Add confirmation dialog to chore delete button

### DIFF
--- a/web/src/components/admin/ChoresTab.tsx
+++ b/web/src/components/admin/ChoresTab.tsx
@@ -23,7 +23,8 @@ export const ChoresTab: React.FC = () => {
 
   useEffect(() => { load(); }, [load]);
 
-  const handleDelete = async (id: number) => {
+  const handleDelete = async (id: number, name: string) => {
+    if (!confirm(`Delete chore "${name}"? This action cannot be undone.`)) return;
     await api.chores.delete(id);
     load();
   };
@@ -85,7 +86,7 @@ export const ChoresTab: React.FC = () => {
                 <button className={styles.iconBtn} title="Edit" aria-label="Edit chore" onClick={(e) => { e.stopPropagation(); handleEdit(chore); }}>
                   <Edit2 size={16} />
                 </button>
-                <button className={clsx(styles.iconBtn, styles.iconBtnDanger)} title="Delete" aria-label="Delete chore" onClick={(e) => { e.stopPropagation(); handleDelete(chore.id); }}>
+                <button className={clsx(styles.iconBtn, styles.iconBtnDanger)} title="Delete" aria-label="Delete chore" onClick={(e) => { e.stopPropagation(); handleDelete(chore.id, chore.name); }}>
                   <Trash2 size={16} />
                 </button>
               </div>


### PR DESCRIPTION
Prevents accidental deletion while scrolling by prompting with the
chore name before proceeding. Follows the same confirm() pattern used
in ApprovalsTab and UsersTab.

https://claude.ai/code/session_01PY3sFiX6ugmD6naUrwveDf