### PR TITLE
Preserve photo + AI approval across uncheck/recheck

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2148,6 +2148,86 @@ func TestDoubleUncheckIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestReviveBonusReevaluatesGate verifies that a bonus chore initially
+// credited 0 points (because required/core weren't done yet) correctly
+// earns its full points on revive if the kid has since qualified. All
+// point changes must still flow through point_transactions.
+func TestReviveBonusReevaluatesGate(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	// Required core chore (gates bonus points).
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Make Bed", "category": "core", "points_value": 5,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	// Bonus chore.
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Extra Vacuum", "category": "bonus", "points_value": 10,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	today := time.Now().Format(model.DateFormat)
+
+	// Complete the bonus first — core is still pending, so bonus credits 0.
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 (bonus gated), got %v", pts["balance"])
+	}
+
+	// Uncheck the bonus (soft-delete).
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/2/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+
+	// Now finish the core chore — bonus gate now passes.
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 5 {
+		t.Fatalf("expected 5 after core complete, got %v", pts["balance"])
+	}
+
+	// Recheck the bonus — revive should re-evaluate the gate and credit
+	// the full 10 points (not leave it at the stale 0).
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 15 {
+		t.Fatalf("expected 15 (5 core + 10 revived bonus), got %v", pts["balance"])
+	}
+
+	// Uncheck + recheck a second time — should NOT double-credit the bonus.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/2/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 15 {
+		t.Fatalf("expected balance stable at 15 on second revive (no double-credit), got %v", pts["balance"])
+	}
+}
+
 // =================== BCRYPT PASSCODE TESTS ===================
 
 func TestBcryptPasscodeRoundTrip(t *testing.T) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2056,6 +2056,98 @@ func TestRecheckPreservesApprovedPhotoAndPoints(t *testing.T) {
 	}
 }
 
+// TestDoubleUncheckIsIdempotent verifies that unchecking an already-unchecked
+// (soft-deleted) completion does not double-debit the child's balance and does
+// not hard-delete the preserved row. The second DELETE must be a no-op so a
+// subsequent recheck still revives the original completion with its photo +
+// approval metadata intact.
+func TestDoubleUncheckIsIdempotent(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Clean Room", "category": "core", "points_value": 10,
+		"requires_photo": true, "photo_source": "child",
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	today := time.Now().Format(model.DateFormat)
+
+	// Approve via photo URL.
+	resp := env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+		"photo_url":       "/uploads/room.jpg",
+	}, adminHeaders(), http.StatusCreated)
+	var firstCC map[string]any
+	decodeBody(t, resp, &firstCC)
+	firstID := int64(firstCC["id"].(float64))
+
+	// Balance 10.
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 after complete, got %v", pts["balance"])
+	}
+
+	// First uncheck — should debit once (balance 0) and soft-delete the row.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 after first uncheck, got %v", pts["balance"])
+	}
+
+	// Second uncheck on an already-soft-deleted row must NOT debit again and
+	// must NOT hard-delete the preserved row.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected balance to remain 0 after double uncheck, got %v", pts["balance"])
+	}
+
+	// The soft-deleted row must still exist with uncompleted_at set.
+	var rowCount int
+	var uncompletedAtNull bool
+	if err := env.db.QueryRow(
+		`SELECT COUNT(*), MIN(CASE WHEN uncompleted_at IS NULL THEN 1 ELSE 0 END)
+		 FROM chore_completions WHERE id = ?`, firstID).Scan(&rowCount, &uncompletedAtNull); err != nil {
+		t.Fatalf("failed to query completion row: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("expected soft-deleted row to be preserved after double uncheck, got %d rows", rowCount)
+	}
+	if uncompletedAtNull {
+		t.Fatal("expected uncompleted_at to still be set after double uncheck")
+	}
+
+	// Recheck — must revive original completion with photo preserved and
+	// balance restored to 10 exactly once.
+	resp = env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	var revived map[string]any
+	decodeBody(t, resp, &revived)
+	if int64(revived["id"].(float64)) != firstID {
+		t.Fatalf("expected same completion id %d on revive, got %v", firstID, revived["id"])
+	}
+	if revived["photo_url"] != "/uploads/room.jpg" {
+		t.Fatalf("expected photo preserved after double-uncheck + recheck, got %+v", revived)
+	}
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected balance 10 after revive, got %v", pts["balance"])
+	}
+}
+
 // =================== BCRYPT PASSCODE TESTS ===================
 
 func TestBcryptPasscodeRoundTrip(t *testing.T) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1964,6 +1964,98 @@ func TestUncompleteNormalPointsReversed(t *testing.T) {
 	}
 }
 
+func TestRecheckPreservesApprovedPhotoAndPoints(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	// Chore that requires a photo.
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Clean Room", "category": "core", "points_value": 10,
+		"requires_photo": true, "photo_source": "child",
+	}, adminHeaders())
+
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	today := time.Now().Format(model.DateFormat)
+
+	// Complete with a photo URL — we don't have an AI reviewer in tests so
+	// this ends up as a normal approved completion with the photo stored.
+	resp := env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+		"photo_url":       "/uploads/room.jpg",
+	}, adminHeaders(), http.StatusCreated)
+	var firstCC map[string]any
+	decodeBody(t, resp, &firstCC)
+	firstID := int64(firstCC["id"].(float64))
+	if firstCC["photo_url"] != "/uploads/room.jpg" {
+		t.Fatalf("expected photo stored, got %+v", firstCC)
+	}
+
+	// Balance should be 10.
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 after complete, got %v", pts["balance"])
+	}
+
+	// Uncheck.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 after uncheck, got %v", pts["balance"])
+	}
+
+	// Re-check WITHOUT providing a photo. The backend should find the
+	// soft-deleted approved completion and revive it — not demand a new photo.
+	resp = env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	var revivedCC map[string]any
+	decodeBody(t, resp, &revivedCC)
+	if int64(revivedCC["id"].(float64)) != firstID {
+		t.Fatalf("expected same completion id %d, got %v", firstID, revivedCC["id"])
+	}
+	if revivedCC["photo_url"] != "/uploads/room.jpg" {
+		t.Fatalf("expected photo preserved on revival, got %+v", revivedCC)
+	}
+	if revivedCC["status"] != "approved" {
+		t.Fatalf("expected status=approved on revival, got %v", revivedCC["status"])
+	}
+
+	// Balance should be back to 10.
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 after revival, got %v", pts["balance"])
+	}
+
+	// Uncheck + recheck a second time should still work correctly.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 after second uncheck, got %v", pts["balance"])
+	}
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 after second revival, got %v", pts["balance"])
+	}
+}
+
 // =================== BCRYPT PASSCODE TESTS ===================
 
 func TestBcryptPasscodeRoundTrip(t *testing.T) {

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -439,7 +439,44 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existing != nil {
-		if existing.Status == model.StatusAIRejected {
+		if existing.UncompletedAt != nil {
+			// Soft-deleted prior completion exists. Approved + pending rows
+			// are revived in place so the kid keeps the photo / AI feedback /
+			// approval metadata and doesn't have to retake a photo after an
+			// accidental uncheck. ai_rejected and rejected rows should not
+			// be revivable — treat them as fresh retry targets by hard-deleting
+			// and falling through to the normal complete flow.
+			if existing.Status == model.StatusApproved || existing.Status == model.StatusPending {
+				if err := h.store.ReviveCompletion(r.Context(), existing.ID); err != nil {
+					writeError(w, http.StatusInternalServerError, "failed to revive completion")
+					return
+				}
+				// Restore the child's balance by deleting the chore_uncomplete
+				// debit rows that were inserted when they unchecked. Crediting
+				// a new chore_complete row would double-count on subsequent
+				// unchecks (since GetNetPointsForCompletion would return a
+				// higher number), so we surgically remove the debit instead.
+				if existing.Status == model.StatusApproved {
+					if _, err := h.store.ReverseUncompleteDebits(r.Context(), existing.ID); err != nil {
+						log.Printf("error reversing uncomplete debits for completion %d: %v", existing.ID, err)
+					}
+					// Recalculate streak after revival
+					if err := h.store.RecalculateStreak(r.Context(), existing.CompletedBy, req.CompletionDate); err != nil {
+						log.Printf("error recalculating streak for user %d: %v", existing.CompletedBy, err)
+					}
+				}
+				// Clear uncompleted_at on the returned payload too
+				existing.UncompletedAt = nil
+				writeJSON(w, http.StatusCreated, existing)
+				return
+			}
+			// ai_rejected / rejected soft-deleted: hard-delete the row so the
+			// retry flow that follows can create a fresh completion.
+			if err := h.store.UncompleteChore(r.Context(), scheduleID, req.CompletionDate); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to clear previous attempt")
+				return
+			}
+		} else if existing.Status == model.StatusAIRejected {
 			// Allow retry — delete the rejected attempt so we don't end up
 			// with duplicate rows (one ai_rejected + one approved) which
 			// confuses the points-decay checker.

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -460,11 +460,36 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 					if _, err := h.store.ReverseUncompleteDebits(r.Context(), existing.ID); err != nil {
 						log.Printf("error reversing uncomplete debits for completion %d: %v", existing.ID, err)
 					}
+					// Bonus chores that were originally credited 0 points (because
+					// required/core weren't done yet) can now qualify if the kid has
+					// since finished the rest of the day. Re-run the gate and credit
+					// the difference via a fresh chore_complete transaction (all
+					// point changes must go through point_transactions per
+					// CLAUDE.md). We only ever credit the delta, so stacking
+					// unchecks/rechecks can't multi-credit the bonus.
+					reviveChore, _ := h.store.GetChore(r.Context(), schedule.ChoreID)
+					if reviveChore != nil && reviveChore.Category == model.CategoryBonus {
+						if h.shouldAwardBonusPoints(r.Context(), existing.CompletedBy, req.CompletionDate) {
+							fullPts, _ := h.store.GetChorePointsForSchedule(r.Context(), scheduleID)
+							alreadyCredited, _ := h.store.GetNetPointsForCompletion(r.Context(), existing.ID)
+							delta := fullPts - alreadyCredited
+							if delta > 0 {
+								if err := h.store.CreditChorePoints(r.Context(), existing.CompletedBy, existing.ID, delta); err != nil {
+									log.Printf("error crediting bonus delta on revive for completion %d: %v", existing.ID, err)
+								}
+							}
+						}
+					}
 					// Recalculate streak after revival
 					if err := h.store.RecalculateStreak(r.Context(), existing.CompletedBy, req.CompletionDate); err != nil {
 						log.Printf("error recalculating streak for user %d: %v", existing.CompletedBy, err)
 					}
 				}
+				// Note: we intentionally do NOT fire EventChoreCompleted on
+				// revive. A revive isn't a fresh completion — it's reversing an
+				// accidental uncheck — and firing would spam downstream webhook
+				// consumers (Home Assistant scripts, push notifications) with
+				// duplicate events. Revisit if product needs differ.
 				// Clear uncompleted_at on the returned payload too
 				existing.UncompletedAt = nil
 				writeJSON(w, http.StatusCreated, existing)

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -755,6 +755,15 @@ func (h *ChoreHandler) Uncomplete(w http.ResponseWriter, r *http.Request) {
 
 	// Get completion before deleting so we can reverse points
 	existing, _ := h.store.GetCompletionForScheduleDate(r.Context(), scheduleID, dateStr)
+	// If the completion is already soft-deleted, short-circuit: don't debit
+	// again (GetNetPointsForCompletion ignores chore_uncomplete rows, so the
+	// already-debited amount would be re-debited), and don't call the store's
+	// UncompleteChore (its fallback DELETE would destroy the preserved row).
+	// The endpoint is idempotent.
+	if existing != nil && existing.UncompletedAt != nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	var completedBy int64
 	if existing != nil {
 		completedBy = existing.CompletedBy

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -118,6 +118,11 @@ type ChoreCompletion struct {
 	CompletionDate  string     `json:"completion_date"`
 	AIFeedback      string     `json:"ai_feedback,omitempty"`
 	AIConfidence    float64    `json:"ai_confidence,omitempty"`
+	// UncompletedAt, when non-nil, marks a soft-deleted completion. The row
+	// is preserved (photo + AI metadata + approval) so a kid can un-check and
+	// re-check a chore without losing the approved state. Reader queries
+	// exposing "is this done?" must treat non-nil UncompletedAt as not done.
+	UncompletedAt *time.Time `json:"uncompleted_at,omitempty"`
 }
 
 // --- Points & Rewards ---

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -240,12 +240,14 @@ func (s *Store) GetScheduledChoresForUser(ctx context.Context, userID int64, dat
 			   AND cs2.id != cs.id
 			   AND cc2.completion_date = ?
 			   AND cc2.status != 'ai_rejected'
+			   AND cc2.uncompleted_at IS NULL
 			 LIMIT 1) as completed_by_sibling_name
 		FROM chore_schedules cs
 		JOIN chores c ON c.id = cs.chore_id
 		LEFT JOIN chore_completions cc ON cc.id = (
 				SELECT cc3.id FROM chore_completions cc3
 				WHERE cc3.chore_schedule_id = cs.id AND cc3.completion_date = ?
+				  AND cc3.uncompleted_at IS NULL
 				ORDER BY CASE cc3.status
 					WHEN 'approved' THEN 1
 					WHEN 'pending'  THEN 2
@@ -365,11 +367,72 @@ func (s *Store) CompleteChore(ctx context.Context, cc *model.ChoreCompletion) er
 	return nil
 }
 
+// UncompleteChore removes (or soft-deletes) the completion for a schedule +
+// date. approved and pending completions are soft-deleted (uncompleted_at
+// set) so the kid can re-check without losing the photo + AI approval
+// metadata for the same day. ai_rejected and rejected completions are hard
+// deleted so the retry flow (a fresh photo + AI call) continues to work as
+// before.
 func (s *Store) UncompleteChore(ctx context.Context, scheduleID int64, completionDate string) error {
-	_, err := s.db.ExecContext(ctx,
+	// Only soft-delete live (non-uncompleted) approved/pending rows. Already
+	// soft-deleted rows are left alone — double-uncomplete is a no-op.
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE chore_completions
+		   SET uncompleted_at = CURRENT_TIMESTAMP
+		 WHERE chore_schedule_id = ?
+		   AND completion_date = ?
+		   AND uncompleted_at IS NULL
+		   AND status IN (?, ?)`,
+		scheduleID, completionDate, model.StatusApproved, model.StatusPending)
+	if err != nil {
+		return err
+	}
+	updated, _ := res.RowsAffected()
+	if updated > 0 {
+		return nil
+	}
+	// No approved/pending row found — fall back to the old hard-delete so
+	// ai_rejected / rejected rows are cleared and can be retried fresh.
+	_, err = s.db.ExecContext(ctx,
 		`DELETE FROM chore_completions WHERE chore_schedule_id = ? AND completion_date = ?`,
 		scheduleID, completionDate)
 	return err
+}
+
+// ReviveCompletion clears uncompleted_at on a soft-deleted completion so the
+// row is once again treated as live/completed.
+func (s *Store) ReviveCompletion(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE chore_completions SET uncompleted_at = NULL WHERE id = ?`, id)
+	return err
+}
+
+// ReverseUncompleteDebits deletes any chore_uncomplete transactions that were
+// recorded against the given completion ID. Used when reviving a soft-deleted
+// completion so the child's balance is restored to its pre-uncheck state
+// without double-counting credits (we can't simply re-credit because future
+// unchecks would then debit too much). Returns the absolute amount of debits
+// that were reversed (>= 0).
+func (s *Store) ReverseUncompleteDebits(ctx context.Context, completionID int64) (int, error) {
+	var reversed int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(amount), 0) FROM point_transactions
+		 WHERE reference_id = ? AND reason = ?`,
+		completionID, model.ReasonChoreUncomplete).Scan(&reversed)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM point_transactions WHERE reference_id = ? AND reason = ?`,
+		completionID, model.ReasonChoreUncomplete); err != nil {
+		return 0, err
+	}
+	// reversed is the sum of the debits, which are negative, so the absolute
+	// value represents points restored to the balance.
+	if reversed < 0 {
+		reversed = -reversed
+	}
+	return reversed, nil
 }
 
 func (s *Store) GetSchedule(ctx context.Context, id int64) (*model.ChoreSchedule, error) {
@@ -384,13 +447,16 @@ func (s *Store) GetSchedule(ctx context.Context, id int64) (*model.ChoreSchedule
 	return cs, err
 }
 
+// GetCompletionForScheduleDate returns the completion row for a schedule+date,
+// INCLUDING soft-deleted (uncompleted_at != NULL) rows so the complete-flow
+// can find a prior approved row and revive it without re-running AI.
 func (s *Store) GetCompletionForScheduleDate(ctx context.Context, scheduleID int64, completionDate string) (*model.ChoreCompletion, error) {
 	cc := &model.ChoreCompletion{}
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, chore_schedule_id, completed_by, status, photo_url, approved_by, approved_at, completed_at, completion_date, ai_feedback, ai_confidence
+		`SELECT id, chore_schedule_id, completed_by, status, photo_url, approved_by, approved_at, completed_at, completion_date, ai_feedback, ai_confidence, uncompleted_at
 		 FROM chore_completions WHERE chore_schedule_id = ? AND completion_date = ?`,
 		scheduleID, completionDate).
-		Scan(&cc.ID, &cc.ChoreScheduleID, &cc.CompletedBy, &cc.Status, &cc.PhotoURL, &cc.ApprovedBy, &cc.ApprovedAt, &cc.CompletedAt, &cc.CompletionDate, &cc.AIFeedback, &cc.AIConfidence)
+		Scan(&cc.ID, &cc.ChoreScheduleID, &cc.CompletedBy, &cc.Status, &cc.PhotoURL, &cc.ApprovedBy, &cc.ApprovedAt, &cc.CompletedAt, &cc.CompletionDate, &cc.AIFeedback, &cc.AIConfidence, &cc.UncompletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -401,9 +467,9 @@ func (s *Store) GetCompletionForScheduleDate(ctx context.Context, scheduleID int
 func (s *Store) GetCompletion(ctx context.Context, id int64) (*model.ChoreCompletion, error) {
 	cc := &model.ChoreCompletion{}
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, chore_schedule_id, completed_by, status, photo_url, approved_by, approved_at, completed_at, completion_date, ai_feedback, ai_confidence
+		`SELECT id, chore_schedule_id, completed_by, status, photo_url, approved_by, approved_at, completed_at, completion_date, ai_feedback, ai_confidence, uncompleted_at
 		 FROM chore_completions WHERE id = ?`, id).
-		Scan(&cc.ID, &cc.ChoreScheduleID, &cc.CompletedBy, &cc.Status, &cc.PhotoURL, &cc.ApprovedBy, &cc.ApprovedAt, &cc.CompletedAt, &cc.CompletionDate, &cc.AIFeedback, &cc.AIConfidence)
+		Scan(&cc.ID, &cc.ChoreScheduleID, &cc.CompletedBy, &cc.Status, &cc.PhotoURL, &cc.ApprovedBy, &cc.ApprovedAt, &cc.CompletedAt, &cc.CompletionDate, &cc.AIFeedback, &cc.AIConfidence, &cc.UncompletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -428,6 +494,7 @@ func (s *Store) ListPendingCompletions(ctx context.Context) ([]PendingCompletion
 		JOIN chores c ON c.id = cs.chore_id
 		JOIN users u ON u.id = cc.completed_by
 		WHERE cc.status = ?
+		  AND cc.uncompleted_at IS NULL
 		ORDER BY cc.completed_at DESC
 	`, model.StatusPending)
 	if err != nil {
@@ -1272,7 +1339,8 @@ func (s *Store) FcfsGroupCompletedForDate(ctx context.Context, groupID, date str
 		`SELECT EXISTS(SELECT 1 FROM chore_completions cc
 		   JOIN chore_schedules cs ON cs.id = cc.chore_schedule_id
 		   WHERE cs.fcfs_group_id = ? AND cc.completion_date = ?
-		   AND cc.status NOT IN ('ai_rejected'))`,
+		   AND cc.status NOT IN ('ai_rejected')
+		   AND cc.uncompleted_at IS NULL)`,
 		groupID, date).Scan(&exists)
 	return exists, err
 }
@@ -1691,6 +1759,7 @@ func (s *Store) GetExpiredChores(ctx context.Context, date string, currentTime s
 				SELECT cc3.id FROM chore_completions cc3
 				WHERE cc3.chore_schedule_id = cs.id AND cc3.completion_date = ?
 				  AND cc3.status != 'ai_rejected'
+				  AND cc3.uncompleted_at IS NULL
 				LIMIT 1
 			)
 		WHERE u.paused = 0
@@ -1766,6 +1835,7 @@ func (s *Store) ReportKidSummaries(ctx context.Context, startDate, endDate strin
 			FROM chore_completions cc
 			WHERE cc.completion_date >= ? AND cc.completion_date <= ?
 			AND cc.status = 'approved'
+			AND cc.uncompleted_at IS NULL
 			GROUP BY cc.completed_by
 		) completed ON completed.completed_by = u.id
 		LEFT JOIN (
@@ -1773,6 +1843,7 @@ func (s *Store) ReportKidSummaries(ctx context.Context, startDate, endDate strin
 			FROM chore_completions cc
 			WHERE cc.completion_date >= ? AND cc.completion_date <= ?
 			AND cc.status = 'rejected'
+			AND cc.uncompleted_at IS NULL
 			GROUP BY cc.completed_by
 		) missed ON missed.completed_by = u.id
 		LEFT JOIN (
@@ -1826,6 +1897,7 @@ func (s *Store) ReportMostMissed(ctx context.Context, startDate, endDate string)
 		JOIN chores c ON c.id = cs.chore_id
 		JOIN users u ON u.id = cc.completed_by
 		WHERE cc.status = 'rejected'
+		AND cc.uncompleted_at IS NULL
 		AND cc.completion_date >= ? AND cc.completion_date <= ?
 		GROUP BY c.id, c.title
 		ORDER BY miss_count DESC
@@ -1863,6 +1935,7 @@ func (s *Store) ReportCompletionTrend(ctx context.Context, startDate, endDate st
 			COUNT(*) AS assigned
 		FROM chore_completions cc
 		WHERE cc.completion_date >= ? AND cc.completion_date <= ?
+		  AND cc.uncompleted_at IS NULL
 		GROUP BY cc.completion_date
 		ORDER BY cc.completion_date`
 
@@ -1901,6 +1974,7 @@ func (s *Store) ReportCategoryBreakdown(ctx context.Context, startDate, endDate 
 		JOIN chore_schedules cs ON cs.id = cc.chore_schedule_id
 		JOIN chores c ON c.id = cs.chore_id
 		WHERE cc.completion_date >= ? AND cc.completion_date <= ?
+		  AND cc.uncompleted_at IS NULL
 		GROUP BY c.category
 		ORDER BY c.category`
 
@@ -1979,6 +2053,7 @@ func (s *Store) ReportDayOfWeek(ctx context.Context, startDate, endDate string) 
 			SUM(CASE WHEN cc.status = 'approved' THEN 1 ELSE 0 END) AS total_completed
 		FROM chore_completions cc
 		WHERE cc.completion_date >= ? AND cc.completion_date <= ?
+		  AND cc.uncompleted_at IS NULL
 		GROUP BY dow
 		ORDER BY dow`
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -415,10 +415,17 @@ func (s *Store) UncompleteChore(ctx context.Context, scheduleID int64, completio
 }
 
 // ReviveCompletion clears uncompleted_at on a soft-deleted completion so the
-// row is once again treated as live/completed.
+// row is once again treated as live/completed. completed_at is refreshed to
+// "now" so downstream consumers (activity feeds, streak calculators, "recent
+// completions" queries) see the revival as a recent action. Approval
+// metadata (approved_by / approved_at / photo_url / ai_feedback /
+// ai_confidence / status) is preserved as-is.
 func (s *Store) ReviveCompletion(ctx context.Context, id int64) error {
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE chore_completions SET uncompleted_at = NULL WHERE id = ?`, id)
+		`UPDATE chore_completions
+		   SET uncompleted_at = NULL,
+		       completed_at   = CURRENT_TIMESTAMP
+		 WHERE id = ?`, id)
 	return err
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -391,6 +391,21 @@ func (s *Store) UncompleteChore(ctx context.Context, scheduleID int64, completio
 	if updated > 0 {
 		return nil
 	}
+	// Belt-and-suspenders: if an already-soft-deleted approved/pending row
+	// exists for this schedule+date, treat the operation as a no-op instead
+	// of falling through to the unconditional DELETE below. Without this
+	// guard, a double-uncheck would destroy the preserved row + metadata.
+	var softDeleted int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chore_completions
+		 WHERE chore_schedule_id = ?
+		   AND completion_date = ?
+		   AND uncompleted_at IS NOT NULL
+		   AND status IN (?, ?)`,
+		scheduleID, completionDate, model.StatusApproved, model.StatusPending,
+	).Scan(&softDeleted); err == nil && softDeleted > 0 {
+		return nil
+	}
 	// No approved/pending row found — fall back to the old hard-delete so
 	// ai_rejected / rejected rows are cleared and can be retried fresh.
 	_, err = s.db.ExecContext(ctx,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -508,9 +508,51 @@ func TestUncompleteChore(t *testing.T) {
 		t.Fatalf("UncompleteChore: %v", err)
 	}
 
+	// Approved completions are SOFT-deleted (preserves photo/AI metadata
+	// so the kid can re-check without losing the approval for the day).
+	// The row should still be present with uncompleted_at set.
+	got, _ := s.GetCompletionForScheduleDate(ctx, cs.ID, "2026-03-28")
+	if got == nil {
+		t.Fatalf("expected row to survive as soft-deleted, got nil")
+	}
+	if got.UncompletedAt == nil {
+		t.Errorf("expected uncompleted_at to be set after uncomplete, got nil")
+	}
+
+	// Revive: completion should come back with uncompleted_at cleared.
+	if err := s.ReviveCompletion(ctx, got.ID); err != nil {
+		t.Fatalf("ReviveCompletion: %v", err)
+	}
+	revived, _ := s.GetCompletionForScheduleDate(ctx, cs.ID, "2026-03-28")
+	if revived == nil || revived.UncompletedAt != nil {
+		t.Errorf("expected row revived with uncompleted_at=nil, got %+v", revived)
+	}
+}
+
+func TestUncompleteChore_AIRejectedHardDeletes(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	u := createTestUser(t, s, "Child", "child")
+	c := createTestChore(t, s, "Trash", 5, u.ID)
+	cs := createTestSchedule(t, s, c.ID, u.ID, 3)
+
+	cc := &model.ChoreCompletion{
+		ChoreScheduleID: cs.ID,
+		CompletedBy:     u.ID,
+		Status:          model.StatusAIRejected,
+		CompletionDate:  "2026-03-28",
+	}
+	s.CompleteChore(ctx, cc)
+
+	if err := s.UncompleteChore(ctx, cs.ID, "2026-03-28"); err != nil {
+		t.Fatalf("UncompleteChore: %v", err)
+	}
+
+	// ai_rejected rows should be hard-deleted so the retry flow works.
 	got, _ := s.GetCompletionForScheduleDate(ctx, cs.ID, "2026-03-28")
 	if got != nil {
-		t.Errorf("expected nil after uncomplete, got %+v", got)
+		t.Errorf("expected ai_rejected row to be hard-deleted, got %+v", got)
 	}
 }
 

--- a/migrations/012_uncomplete_soft_delete.down.sql
+++ b/migrations/012_uncomplete_soft_delete.down.sql
@@ -1,6 +1,8 @@
--- Drop the soft-delete column. Any currently-uncompleted (soft-deleted) rows
--- stop being hidden by reader queries, but the app code on the "down" side
--- doesn't know about this column so the rows would look "completed" again.
--- Clear those rows first so the state is sensible after rollback.
-DELETE FROM chore_completions WHERE uncompleted_at IS NOT NULL;
+-- Rollback: drop the partial index first, then the column. Rows that happen
+-- to be soft-deleted (uncompleted_at IS NOT NULL) are LEFT IN PLACE — old
+-- code without this column will treat them as completed again, which is the
+-- correct behavior for a rollback. Deleting approved completions + photos +
+-- AI feedback just because they happen to be toggled off at rollback time
+-- would be destructive and surprising.
+DROP INDEX IF EXISTS idx_completions_uncompleted_at_null;
 ALTER TABLE chore_completions DROP COLUMN uncompleted_at;

--- a/migrations/012_uncomplete_soft_delete.down.sql
+++ b/migrations/012_uncomplete_soft_delete.down.sql
@@ -1,0 +1,6 @@
+-- Drop the soft-delete column. Any currently-uncompleted (soft-deleted) rows
+-- stop being hidden by reader queries, but the app code on the "down" side
+-- doesn't know about this column so the rows would look "completed" again.
+-- Clear those rows first so the state is sensible after rollback.
+DELETE FROM chore_completions WHERE uncompleted_at IS NOT NULL;
+ALTER TABLE chore_completions DROP COLUMN uncompleted_at;

--- a/migrations/012_uncomplete_soft_delete.up.sql
+++ b/migrations/012_uncomplete_soft_delete.up.sql
@@ -4,3 +4,12 @@
 -- currently treated as "not completed" by the UI, but the data survives so
 -- the user can toggle back on without redoing the photo / AI review.
 ALTER TABLE chore_completions ADD COLUMN uncompleted_at DATETIME;
+
+-- Hot-path readers (GetScheduledChoresForUser, FCFS checks, daily summaries)
+-- all filter on uncompleted_at IS NULL. A partial index avoids scanning the
+-- long tail of soft-deleted rows that accumulate over time. SQLite has
+-- supported partial indexes since 3.8, and modernc.org/sqlite ships a
+-- recent-enough version.
+CREATE INDEX idx_completions_uncompleted_at_null
+  ON chore_completions(chore_schedule_id, completion_date)
+  WHERE uncompleted_at IS NULL;

--- a/migrations/012_uncomplete_soft_delete.up.sql
+++ b/migrations/012_uncomplete_soft_delete.up.sql
@@ -1,0 +1,6 @@
+-- Soft-delete support for chore_completions so that an accidental uncheck +
+-- recheck preserves approved photo + AI feedback + approval metadata for the
+-- same schedule + date. A non-null uncompleted_at means the completion is
+-- currently treated as "not completed" by the UI, but the data survives so
+-- the user can toggle back on without redoing the photo / AI review.
+ALTER TABLE chore_completions ADD COLUMN uncompleted_at DATETIME;

--- a/web/src/pages/Dashboard.module.css
+++ b/web/src/pages/Dashboard.module.css
@@ -576,6 +576,14 @@
   border-color: rgba(255, 255, 255, 0.08);
 }
 
+/* Applied while a complete/uncomplete request is in flight. Visually dims
+ * the tile and blocks further input so a kid double-tapping doesn't fire
+ * two POSTs. */
+.choreCardToggling {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .choreCardExpired {
   opacity: 0.5;
   border-left: 3px solid var(--status-required);

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -179,6 +179,10 @@ export const Dashboard: React.FC = () => {
   const [redeemingId, setRedeemingId] = useState<number | null>(null);
   const [redeemedId, setRedeemedId] = useState<number | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  // Per-schedule-id "request in flight" flag. Prevents double-POSTs when a
+  // kid double-taps a chore tile (common on touchscreens), and lets us grey
+  // out the tile while the backend round-trip is in progress.
+  const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
   const [showThemePicker, setShowThemePicker] = useState(false);
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
@@ -260,6 +264,14 @@ export const Dashboard: React.FC = () => {
 
   const handleToggleComplete = async (chore: ScheduledChore) => {
     if (chore.date !== todayStr) return;
+    // Double-tap / double-POST guard. If a request is already in flight for
+    // this schedule, drop subsequent clicks until it resolves.
+    if (togglingIds.has(chore.schedule_id)) return;
+    setTogglingIds(prev => {
+      const next = new Set(prev);
+      next.add(chore.schedule_id);
+      return next;
+    });
     try {
       if (chore.completed) {
         await api.chores.uncomplete(chore.schedule_id, chore.date);
@@ -306,9 +318,27 @@ export const Dashboard: React.FC = () => {
       if (err instanceof APIError && err.status === 422 && err.data?.ai_review) {
         setAiFeedback(prev => ({ ...prev, [chore.schedule_id]: { text: err.data.ai_review.feedback, audioUrl: err.data.ai_review.feedback_audio } }));
         await loadChores();
-      } else {
+      } else if (err instanceof APIError && (err.status === 400 || err.status === 422)) {
+        // Client-level validation errors are surfaced via more specific paths
+        // (photo modal, AI feedback). Log for diagnostics but don't toast.
         console.error(err);
+      } else {
+        // 500s, network failures, etc. — surface to the user rather than
+        // leaving the tile silently stuck.
+        console.error(err);
+        const message = err instanceof APIError && err.data?.error
+          ? String(err.data.error)
+          : "Couldn't save — try again";
+        setToast(message);
+        setTimeout(() => setToast(null), 3000);
       }
+    } finally {
+      setTogglingIds(prev => {
+        if (!prev.has(chore.schedule_id)) return prev;
+        const next = new Set(prev);
+        next.delete(chore.schedule_id);
+        return next;
+      });
     }
   };
 
@@ -509,6 +539,7 @@ export const Dashboard: React.FC = () => {
     const isLocked = !chore.available && !chore.completed;
     const isExpired = chore.expired && !chore.completed;
     const isPointsLocked = isToday && chore.completed && chore.category === 'core' && !allRequiredDone;
+    const isToggling = togglingIds.has(chore.schedule_id);
 
     if (isWeekly) {
       return (
@@ -519,9 +550,10 @@ export const Dashboard: React.FC = () => {
             chore.completed && styles.calendarChoreCompleted,
             !isToday && styles.calendarChorePast,
             isLocked && styles.calendarChoreLocked,
-            isPointsLocked && styles.calendarChorePointsLocked
+            isPointsLocked && styles.calendarChorePointsLocked,
+            isToggling && styles.choreCardToggling
           )}
-          onClick={() => isToday && !isLocked && handleToggleComplete(chore)}
+          onClick={() => !isToggling && isToday && !isLocked && handleToggleComplete(chore)}
         >
           <div className={clsx(styles.calendarStatus, chore.completed && styles.calendarStatusCompleted)}>
             {chore.completed ? <CheckCircle size={14} /> : (isLocked ? <Lock size={10} /> : null)}
@@ -563,11 +595,12 @@ export const Dashboard: React.FC = () => {
             isLocked && styles.choreCardLocked,
             isExpired && styles.choreCardExpired,
             isPointsLocked && styles.choreCardPointsLocked,
+            isToggling && styles.choreCardToggling,
             (aiFeedback[chore.schedule_id] || (chore.completion_status === 'ai_rejected' && chore.ai_feedback) || (chore.completed && chore.completion_status === 'approved' && chore.ai_feedback)) && styles.choreCardHasFeedback
           )}
-          onTouchStart={canSwipe ? (e) => handleTouchStart(e, choreKey) : undefined}
-          onTouchMove={canSwipe ? (e) => handleTouchMove(e, chore) : undefined}
-          onTouchEnd={canSwipe ? (e) => handleSwipeEnd(e, chore) : undefined}
+          onTouchStart={canSwipe && !isToggling ? (e) => handleTouchStart(e, choreKey) : undefined}
+          onTouchMove={canSwipe && !isToggling ? (e) => handleTouchMove(e, chore) : undefined}
+          onTouchEnd={canSwipe && !isToggling ? (e) => handleSwipeEnd(e, chore) : undefined}
         >
         <div className={styles.choreInfo}>
           <h3 className={styles.choreTitle}>
@@ -645,6 +678,7 @@ export const Dashboard: React.FC = () => {
               )}
               <button
                 onClick={() => handleToggleComplete(chore)}
+                disabled={isToggling}
                 className={clsx(styles.completeBtn, chore.completed && !chore.completed_by_sibling && styles.completeBtnActive, chore.completed && chore.completed_by_sibling && styles.completeBtnSibling)}
                 aria-label={chore.completed ? "Mark incomplete" : "Mark complete"}
               >

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -265,9 +265,30 @@ export const Dashboard: React.FC = () => {
         await api.chores.uncomplete(chore.schedule_id, chore.date);
       } else {
         const photoSource = chore.photo_source || 'child';
-        if (chore.requires_photo && photoSource === 'child') {
-          setQrChore(chore);
-          return;
+        const needsPhoto = chore.requires_photo && photoSource === 'child';
+        if (needsPhoto) {
+          // Try to complete without a photo first — the backend will revive
+          // a prior soft-deleted approved completion (kept around so an
+          // accidental uncheck + recheck doesn't wipe the photo/AI feedback
+          // for today). If there's no prior completion, the backend returns
+          // 400 "photo required" and we fall through to the QR modal.
+          try {
+            await api.chores.complete(chore.schedule_id, chore.date);
+            setAiFeedback(prev => {
+              const next = { ...prev };
+              delete next[chore.schedule_id];
+              return next;
+            });
+            onChoreFinished();
+            return;
+          } catch (e) {
+            if (e instanceof APIError && e.status === 400) {
+              // No prior completion to revive — show the photo capture modal.
+              setQrChore(chore);
+              return;
+            }
+            throw e;
+          }
         }
         await api.chores.complete(chore.schedule_id, chore.date);
         // Clear any previous AI feedback for this chore on success


### PR DESCRIPTION
## Summary
Fixes a bug where accidentally unchecking an AI-approved photo chore wiped the photo and AI feedback, forcing the kid to start over on recheck.

Switches `UncompleteChore` from hard delete to soft delete (via a new `uncompleted_at` column) for `approved` / `pending` rows. On recheck, the prior completion is revived with photo, AI feedback, and approval state intact — no new photo, no new AI call. `ai_rejected` / `rejected` rows still hard-delete to preserve the existing retry-from-scratch flow.

## Changes
- **Migration 012** — adds nullable `uncompleted_at` column (up + down verified)
- **Store** — `UncompleteChore` soft-deletes approved/pending; new `ReviveCompletion` + `ReverseUncompleteDebits` (reverses by deleting the uncomplete transaction so repeat cycles stay point-accurate)
- **Complete handler** — on a soft-deleted approved/pending row, revives and returns; skips photo + AI
- **Query audit** — `uncompleted_at IS NULL` added to all completion readers: `GetScheduledChoresForUser` (main + FCFS sibling), `ListPendingCompletions`, `FcfsGroupCompletedForDate`, `GetExpiredChores`, 5 report queries. `GetCompletion` / `GetCompletionForScheduleDate` intentionally still return soft-deleted rows so the revive path can find them.
- **Frontend** — `Dashboard.tsx` `handleToggleComplete` calls `complete()` first and only shows the QR modal on 400, so revived completions skip the photo prompt.

## Notes
- `pending` rows preserve the photo on uncheck but do **not** auto-approve on revival — they come back as pending.
- FCFS uncomplete still hard-deletes (out of scope, unchanged behavior).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `cd web && npm run build && npm test` (56 tests pass)
- [x] New test `TestRecheckPreservesApprovedPhotoAndPoints` covers full complete→uncheck→recheck→uncheck→recheck cycle with point balance assertions
- [x] New test `TestUncompleteChore_AIRejectedHardDeletes` confirms retry semantics preserved
- [ ] Manual: approve a photo chore with AI, uncheck, recheck — confirm photo + feedback persist and points re-credit

https://claude.ai/code/session_01VRZJ8quPCV5NCEkMXoeMYc