### PR TITLE
fix(points): retroactively credit bonus completions when gate opens

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2228,6 +2228,79 @@ func TestReviveBonusReevaluatesGate(t *testing.T) {
 	}
 }
 
+// TestRequiredCompletionOpensBonusGate verifies that completing a required/core
+// chore retroactively credits any already-approved bonus completions that
+// were capped at 0 points because the gate was closed at the time. Previously
+// the retroactive credit only fired on revive, so the kid had to uncheck and
+// recheck the bonus to "see" the points they had earned.
+func TestRequiredCompletionOpensBonusGate(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	// Required chore worth 5 points.
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Make Bed", "category": "required", "points_value": 5,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	// Bonus chore worth 20 points.
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Extra Vacuum", "category": "bonus", "points_value": 20,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	today := time.Now().Format(model.DateFormat)
+
+	// Complete the bonus first — required is still pending, so bonus credits 0.
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 (bonus gated), got %v", pts["balance"])
+	}
+
+	// Now complete the required chore — this should both credit the required
+	// chore's 5 points AND retroactively credit the bonus chore's 20 points.
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 25 {
+		t.Fatalf("expected 25 (5 required + 20 retro bonus), got %v", pts["balance"])
+	}
+
+	// Uncheck + recheck the bonus should leave the balance stable — no
+	// double-credit from the retroactive path stacking with revive.
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/2/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 5 {
+		t.Fatalf("expected 5 after uncheck bonus, got %v", pts["balance"])
+	}
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 25 {
+		t.Fatalf("expected 25 after recheck, got %v", pts["balance"])
+	}
+}
+
 // =================== BCRYPT PASSCODE TESTS ===================
 
 func TestBcryptPasscodeRoundTrip(t *testing.T) {

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -664,6 +664,13 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Completing a required/core chore can be the event that opens the
+		// bonus gate. Retroactively credit any approved bonus completions for
+		// this user/date that were originally capped at 0.
+		if chore != nil && (chore.Category == model.CategoryRequired || chore.Category == model.CategoryCore) {
+			h.creditPendingBonusPoints(r.Context(), completedBy, req.CompletionDate)
+		}
+
 		// Recalculate streak
 		if err := h.store.RecalculateStreak(r.Context(), completedBy, req.CompletionDate); err != nil {
 			log.Printf("error recalculating streak for user %d: %v", completedBy, err)
@@ -901,6 +908,13 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 			if err := h.store.CreditChorePoints(r.Context(), completion.CompletedBy, completion.ID, pts); err != nil {
 				log.Printf("error crediting chore points for user %d completion %d: %v", completion.CompletedBy, completion.ID, err)
 			}
+		}
+
+		// Approving a required/core completion can be the event that opens
+		// the bonus gate. Retroactively credit any approved bonus completions
+		// for this user/date that were originally capped at 0.
+		if chore != nil && (chore.Category == model.CategoryRequired || chore.Category == model.CategoryCore) {
+			h.creditPendingBonusPoints(r.Context(), completion.CompletedBy, completion.CompletionDate)
 		}
 	}
 
@@ -1284,4 +1298,48 @@ func (h *ChoreHandler) shouldAwardBonusPoints(ctx context.Context, userID int64,
 		}
 	}
 	return true
+}
+
+// creditPendingBonusPoints retroactively credits approved bonus completions
+// for the given user/date that were capped at 0 points because the
+// required/core gate was closed at the time of their approval. Call after an
+// event that can open the gate (a required or core chore transitioning to
+// approved). No-op if the gate is still closed. Only the delta between the
+// chore's full value and what's already on the completion is credited, so
+// repeated calls can't multi-credit the same completion.
+func (h *ChoreHandler) creditPendingBonusPoints(ctx context.Context, userID int64, date string) {
+	if !h.shouldAwardBonusPoints(ctx, userID, date) {
+		return
+	}
+	scheduled, err := h.store.GetScheduledChoresForUser(ctx, userID, []string{date}, time.Now())
+	if err != nil {
+		log.Printf("error fetching scheduled chores for bonus reevaluation user %d date %s: %v", userID, date, err)
+		return
+	}
+	for _, sc := range scheduled {
+		if sc.Category != model.CategoryBonus || sc.CompletionID == nil {
+			continue
+		}
+		// Only approved completions get points; pending bonus completions
+		// are credited when the admin approves them.
+		if sc.CompletionStatus == nil || *sc.CompletionStatus != model.StatusApproved {
+			continue
+		}
+		fullPts, err := h.store.GetChorePointsForSchedule(ctx, sc.ScheduleID)
+		if err != nil {
+			log.Printf("error fetching points for schedule %d: %v", sc.ScheduleID, err)
+			continue
+		}
+		alreadyCredited, err := h.store.GetNetPointsForCompletion(ctx, *sc.CompletionID)
+		if err != nil {
+			log.Printf("error fetching net points for completion %d: %v", *sc.CompletionID, err)
+			continue
+		}
+		delta := fullPts - alreadyCredited
+		if delta > 0 {
+			if err := h.store.CreditChorePoints(ctx, userID, *sc.CompletionID, delta); err != nil {
+				log.Printf("error crediting retroactive bonus points for user %d completion %d: %v", userID, *sc.CompletionID, err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Completing a required/core chore can be the event that unlocks the
bonus-points gate for the day. Previously only the revive path (uncheck
+ recheck of the bonus) re-evaluated the gate, so a kid who completed a
bonus chore first, then a required chore, would see only the required
chore's points until they manually toggled the bonus. Now the Complete
and Approve endpoints retroactively credit the delta for any approved
bonus completions whose points were originally capped at 0.