### PR TITLE
Reward commitments: let kids save toward a chosen reward

### DIFF
--- a/internal/api/points.go
+++ b/internal/api/points.go
@@ -22,10 +22,24 @@ func (h *PointsHandler) GetUserPoints(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid user id")
 		return
 	}
+	// SUM(point_transactions.amount) is naturally the spendable balance:
+	// commit_to_goal entries already debit it. Surface "balance" as the
+	// spendable number the kid can spend on cheaper rewards, plus a separate
+	// "committed" total + the active commitment (if any) so the UI can show
+	// progress toward the saved goal.
 	balance, err := h.store.GetPointBalance(r.Context(), userID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get balance")
 		return
+	}
+	commitment, err := h.store.GetActiveCommitmentForUser(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get commitment")
+		return
+	}
+	committed := 0
+	if commitment != nil {
+		committed = commitment.AmountSaved
 	}
 	txs, err := h.store.ListPointTransactions(r.Context(), userID, 50)
 	if err != nil {
@@ -36,8 +50,10 @@ func (h *PointsHandler) GetUserPoints(w http.ResponseWriter, r *http.Request) {
 		txs = []model.PointTransaction{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"balance":      balance,
-		"transactions": txs,
+		"balance":           balance,
+		"committed":         committed,
+		"active_commitment": commitment,
+		"transactions":      txs,
 	})
 }
 

--- a/internal/api/rewards.go
+++ b/internal/api/rewards.go
@@ -228,3 +228,114 @@ func (h *RewardHandler) ListRedemptions(w http.ResponseWriter, r *http.Request) 
 	}
 	writeJSON(w, http.StatusOK, redemptions)
 }
+
+// --- Commitments ---
+
+func (h *RewardHandler) ListCommitments(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	commitments, err := h.store.ListCommitmentsForUser(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list commitments")
+		return
+	}
+	if commitments == nil {
+		commitments = []model.RewardCommitment{}
+	}
+	writeJSON(w, http.StatusOK, commitments)
+}
+
+func (h *RewardHandler) Commit(w http.ResponseWriter, r *http.Request) {
+	rewardID, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid reward id")
+		return
+	}
+	var req struct {
+		AutoContributePercent int `json:"auto_contribute_percent"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		// Body is optional; default to 0%.
+		req.AutoContributePercent = 0
+	}
+	user := UserFromContext(r.Context())
+	c, err := h.store.CreateCommitment(r.Context(), user.ID, rewardID, req.AutoContributePercent)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, c)
+}
+
+func (h *RewardHandler) Contribute(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid commitment id")
+		return
+	}
+	var req struct {
+		Amount int `json:"amount"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Amount <= 0 {
+		writeError(w, http.StatusBadRequest, "amount must be positive")
+		return
+	}
+	user := UserFromContext(r.Context())
+	if err := h.store.ContributeToCommitment(r.Context(), user.ID, id, req.Amount); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	c, err := h.store.GetActiveCommitmentForUser(r.Context(), user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reload commitment")
+		return
+	}
+	writeJSON(w, http.StatusOK, c)
+}
+
+func (h *RewardHandler) SetAutoContribute(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid commitment id")
+		return
+	}
+	var req struct {
+		Percent int `json:"percent"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	user := UserFromContext(r.Context())
+	if err := h.store.SetCommitmentAutoContributePercent(r.Context(), user.ID, id, req.Percent); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	c, err := h.store.GetActiveCommitmentForUser(r.Context(), user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reload commitment")
+		return
+	}
+	writeJSON(w, http.StatusOK, c)
+}
+
+func (h *RewardHandler) BreakCommitment(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid commitment id")
+		return
+	}
+	user := UserFromContext(r.Context())
+	if err := h.store.BreakCommitment(r.Context(), user.ID, id); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -82,6 +82,14 @@ func NewRouter(s *store.Store, dispatcher *webhook.Dispatcher) (*chi.Mux, *Chore
 			r.Get("/rewards", rewards.List)
 			r.Post("/rewards/{id}/redeem", rewards.Redeem)
 
+			// Reward commitments — kids commit points toward a chosen reward
+			// and watch progress instead of being tempted to drain spendable.
+			r.Get("/users/{id}/commitments", rewards.ListCommitments)
+			r.Post("/rewards/{id}/commit", rewards.Commit)
+			r.Post("/commitments/{id}/contribute", rewards.Contribute)
+			r.Put("/commitments/{id}/auto-contribute", rewards.SetAutoContribute)
+			r.Delete("/commitments/{id}", rewards.BreakCommitment)
+
 			// Admin-only routes
 			r.Group(func(r chi.Router) {
 				r.Use(RequireAdmin)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -29,6 +29,15 @@ const (
 	ReasonExpiryPenalty   = "expiry_penalty"
 	ReasonPointsDecay     = "points_decay"
 	ReasonMissedChore     = "missed_chore"
+	ReasonCommitToGoal    = "commit_to_goal"
+	ReasonGoalBreak       = "goal_break"
+)
+
+// Commitment statuses
+const (
+	CommitmentActive    = "active"
+	CommitmentRedeemed  = "redeemed"
+	CommitmentCancelled = "cancelled"
 )
 
 // Photo source modes
@@ -165,6 +174,24 @@ type RewardRedemption struct {
 	UserID      int64     `json:"user_id"`
 	PointsSpent int       `json:"points_spent"`
 	CreatedAt   time.Time `json:"created_at"`
+}
+
+// RewardCommitment represents a kid earmarking points toward a chosen reward.
+// AmountSaved is derived from point_transactions referencing this commitment
+// and is populated by the store layer (not stored on the row itself).
+type RewardCommitment struct {
+	ID                    int64      `json:"id"`
+	UserID                int64      `json:"user_id"`
+	RewardID              int64      `json:"reward_id"`
+	RewardName            string     `json:"reward_name,omitempty"`
+	RewardIcon            string     `json:"reward_icon,omitempty"`
+	TargetCost            int        `json:"target_cost"`
+	AmountSaved           int        `json:"amount_saved"`
+	AutoContributePercent int        `json:"auto_contribute_percent"`
+	Status                string     `json:"status"`
+	CreatedAt             time.Time  `json:"created_at"`
+	RedeemedAt            *time.Time `json:"redeemed_at,omitempty"`
+	CancelledAt           *time.Time `json:"cancelled_at,omitempty"`
 }
 
 // --- Streaks ---

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -622,19 +622,39 @@ func (s *Store) GetChorePointsForSchedule(ctx context.Context, scheduleID int64)
 }
 
 func (s *Store) CreditChorePoints(ctx context.Context, userID, completionID int64, amount int) error {
-	_, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
 		 VALUES (?, ?, ?, ?, '')`,
-		userID, amount, model.ReasonChoreComplete, completionID)
-	return err
+		userID, amount, model.ReasonChoreComplete, completionID); err != nil {
+		return err
+	}
+	if err := s.applyAutoContributeTx(ctx, tx, userID, completionID, amount); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) DebitChorePoints(ctx context.Context, userID, completionID int64, amount int) error {
-	_, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
 		 VALUES (?, ?, ?, ?, '')`,
-		userID, -amount, model.ReasonChoreUncomplete, completionID)
-	return err
+		userID, -amount, model.ReasonChoreUncomplete, completionID); err != nil {
+		return err
+	}
+	if err := s.reverseAutoContributeTx(ctx, tx, userID, completionID); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // GetNetPointsForCompletion returns the net points credited/debited for a specific completion.
@@ -931,7 +951,43 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 		cost = int(customCost.Int64)
 	}
 
-	// Check balance
+	// Look for an active commitment toward this reward. If one exists, the kid
+	// must have saved at least the snapshotted target before they can redeem;
+	// the saved points are still in the ledger as commit_to_goal debits, so we
+	// emit a goal_break to return them to spendable just before the normal
+	// reward_redeem debit. Net effect on the ledger is -target_cost, which is
+	// the same as a standard redemption — but the commitment row gets marked
+	// redeemed and any difference between target_cost and current cost flows
+	// to the kid (we redeem at the snapshotted target, not the current price).
+	var commitmentID int64
+	var commitmentTarget int
+	commitmentRow := tx.QueryRowContext(ctx,
+		`SELECT id, target_cost FROM reward_commitments
+		 WHERE user_id = ? AND reward_id = ? AND status = ?`,
+		userID, rewardID, model.CommitmentActive)
+	if err := commitmentRow.Scan(&commitmentID, &commitmentTarget); err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	if commitmentID != 0 {
+		// Honour the snapshotted target so price changes don't burn the saver.
+		cost = commitmentTarget
+
+		var saved int
+		err = tx.QueryRowContext(ctx,
+			`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+			 WHERE reference_id = ? AND reason IN (?, ?)`,
+			commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved)
+		if err != nil {
+			return nil, err
+		}
+		if saved < commitmentTarget {
+			return nil, fmt.Errorf("not enough saved yet (have %d, need %d)", saved, commitmentTarget)
+		}
+	}
+
+	// Check spendable balance. SUM(point_transactions.amount) is naturally
+	// spendable because commit_to_goal rows already debit it.
 	var balance int
 	err = tx.QueryRowContext(ctx,
 		`SELECT COALESCE(SUM(amount), 0) FROM point_transactions WHERE user_id = ?`, userID).
@@ -939,7 +995,10 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 	if err != nil {
 		return nil, err
 	}
-	if balance < cost {
+	// When redeeming via a fully-funded commitment, the goal_break we're about
+	// to emit will return the saved points first, so spendable+saved must
+	// cover cost — saved >= cost is already verified above, so this passes.
+	if commitmentID == 0 && balance < cost {
 		return nil, fmt.Errorf("insufficient points (have %d, need %d)", balance, cost)
 	}
 
@@ -952,7 +1011,21 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 	}
 	redemptionID, _ := res.LastInsertId()
 
-	// Debit points
+	if commitmentID != 0 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, 'redeemed via commitment')`,
+			userID, cost, model.ReasonGoalBreak, commitmentID); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE reward_commitments SET status = ?, redeemed_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			model.CommitmentRedeemed, commitmentID); err != nil {
+			return nil, err
+		}
+	}
+
+	// Debit points for the redemption
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
 		 VALUES (?, ?, ?, ?, '')`,
@@ -979,6 +1052,412 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 		UserID:      userID,
 		PointsSpent: cost,
 	}, nil
+}
+
+// --- Reward Commitments ---
+
+// ErrActiveCommitmentExists indicates the user already has an active commitment.
+var ErrActiveCommitmentExists = fmt.Errorf("user already has an active commitment")
+
+// scanCommitment fills a RewardCommitment from a row scan and computes the
+// derived AmountSaved from the ledger.
+func (s *Store) hydrateCommitmentSaved(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, c *model.RewardCommitment) error {
+	return q.QueryRowContext(ctx,
+		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+		 WHERE reference_id = ? AND reason IN (?, ?)`,
+		c.ID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&c.AmountSaved)
+}
+
+// GetActiveCommitmentForUser returns the user's active commitment with reward
+// metadata and a derived AmountSaved, or nil if there isn't one.
+func (s *Store) GetActiveCommitmentForUser(ctx context.Context, userID int64) (*model.RewardCommitment, error) {
+	c := &model.RewardCommitment{}
+	var redeemedAt, cancelledAt sql.NullTime
+	err := s.db.QueryRowContext(ctx,
+		`SELECT rc.id, rc.user_id, rc.reward_id, r.name, r.icon, rc.target_cost,
+		        rc.auto_contribute_percent, rc.status, rc.created_at,
+		        rc.redeemed_at, rc.cancelled_at
+		 FROM reward_commitments rc
+		 JOIN rewards r ON r.id = rc.reward_id
+		 WHERE rc.user_id = ? AND rc.status = ?`,
+		userID, model.CommitmentActive).
+		Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon, &c.TargetCost,
+			&c.AutoContributePercent, &c.Status, &c.CreatedAt, &redeemedAt, &cancelledAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if redeemedAt.Valid {
+		c.RedeemedAt = &redeemedAt.Time
+	}
+	if cancelledAt.Valid {
+		c.CancelledAt = &cancelledAt.Time
+	}
+	if err := s.hydrateCommitmentSaved(ctx, s.db, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// ListCommitmentsForUser returns the user's commitments (active + history),
+// most recent first.
+func (s *Store) ListCommitmentsForUser(ctx context.Context, userID int64) ([]model.RewardCommitment, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT rc.id, rc.user_id, rc.reward_id, r.name, r.icon, rc.target_cost,
+		        rc.auto_contribute_percent, rc.status, rc.created_at,
+		        rc.redeemed_at, rc.cancelled_at
+		 FROM reward_commitments rc
+		 JOIN rewards r ON r.id = rc.reward_id
+		 WHERE rc.user_id = ?
+		 ORDER BY rc.created_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []model.RewardCommitment
+	for rows.Next() {
+		var c model.RewardCommitment
+		var redeemedAt, cancelledAt sql.NullTime
+		if err := rows.Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon,
+			&c.TargetCost, &c.AutoContributePercent, &c.Status, &c.CreatedAt,
+			&redeemedAt, &cancelledAt); err != nil {
+			return nil, err
+		}
+		if redeemedAt.Valid {
+			c.RedeemedAt = &redeemedAt.Time
+		}
+		if cancelledAt.Valid {
+			c.CancelledAt = &cancelledAt.Time
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range out {
+		if err := s.hydrateCommitmentSaved(ctx, s.db, &out[i]); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// CreateCommitment opens a new active commitment for the user, snapshotting
+// the reward's effective cost as the target. The kid keeps that price even if
+// admins later raise the reward's cost. Returns ErrActiveCommitmentExists if
+// the user already has an active commitment.
+func (s *Store) CreateCommitment(ctx context.Context, userID, rewardID int64, autoPercent int) (*model.RewardCommitment, error) {
+	if autoPercent < 0 || autoPercent > 100 {
+		return nil, fmt.Errorf("auto_contribute_percent must be between 0 and 100")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Refuse if user has an active commitment.
+	var existing int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT id FROM reward_commitments WHERE user_id = ? AND status = ?`,
+		userID, model.CommitmentActive).Scan(&existing); err == nil {
+		return nil, ErrActiveCommitmentExists
+	} else if err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	// Snapshot the cost the kid sees (per-user override or base cost).
+	var baseCost int
+	var active int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT cost, active FROM rewards WHERE id = ?`, rewardID).Scan(&baseCost, &active); err != nil {
+		return nil, fmt.Errorf("reward not found")
+	}
+	if active != 1 {
+		return nil, fmt.Errorf("reward is not active")
+	}
+
+	// Honour assignments + per-user pricing.
+	var hasAssignments bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM reward_assignments WHERE reward_id = ?)`, rewardID).
+		Scan(&hasAssignments); err != nil {
+		return nil, err
+	}
+	if hasAssignments {
+		var assigned bool
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM reward_assignments WHERE reward_id = ? AND user_id = ?)`,
+			rewardID, userID).Scan(&assigned); err != nil {
+			return nil, err
+		}
+		if !assigned {
+			return nil, fmt.Errorf("reward is not available to you")
+		}
+	}
+	target := baseCost
+	var customCost sql.NullInt64
+	tx.QueryRowContext(ctx,
+		`SELECT custom_cost FROM reward_assignments WHERE reward_id = ? AND user_id = ?`,
+		rewardID, userID).Scan(&customCost)
+	if customCost.Valid {
+		target = int(customCost.Int64)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO reward_commitments (user_id, reward_id, target_cost, auto_contribute_percent)
+		 VALUES (?, ?, ?, ?)`,
+		userID, rewardID, target, autoPercent); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.GetActiveCommitmentForUser(ctx, userID)
+}
+
+// ContributeToCommitment moves `amount` points from the user's spendable
+// balance into their active commitment. The amount is capped at the
+// commitment's remaining target so kids can't over-fund. Returns an error if
+// spendable balance is insufficient.
+func (s *Store) ContributeToCommitment(ctx context.Context, userID, commitmentID int64, amount int) error {
+	if amount <= 0 {
+		return fmt.Errorf("amount must be positive")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var ownerID int64
+	var status string
+	var target int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT user_id, status, target_cost FROM reward_commitments WHERE id = ?`,
+		commitmentID).Scan(&ownerID, &status, &target); err != nil {
+		return fmt.Errorf("commitment not found")
+	}
+	if ownerID != userID {
+		return fmt.Errorf("commitment not owned by user")
+	}
+	if status != model.CommitmentActive {
+		return fmt.Errorf("commitment is not active")
+	}
+
+	var saved int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+		 WHERE reference_id = ? AND reason IN (?, ?)`,
+		commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+		return err
+	}
+	remaining := target - saved
+	if remaining <= 0 {
+		return fmt.Errorf("commitment is already fully funded")
+	}
+	if amount > remaining {
+		amount = remaining
+	}
+
+	var spendable int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(amount), 0) FROM point_transactions WHERE user_id = ?`, userID).
+		Scan(&spendable); err != nil {
+		return err
+	}
+	if spendable < amount {
+		return fmt.Errorf("insufficient spendable points (have %d, need %d)", spendable, amount)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+		 VALUES (?, ?, ?, ?, 'manual')`,
+		userID, -amount, model.ReasonCommitToGoal, commitmentID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SetCommitmentAutoContributePercent updates the auto-contribute percent on
+// an active commitment.
+func (s *Store) SetCommitmentAutoContributePercent(ctx context.Context, userID, commitmentID int64, percent int) error {
+	if percent < 0 || percent > 100 {
+		return fmt.Errorf("percent must be between 0 and 100")
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE reward_commitments SET auto_contribute_percent = ?
+		 WHERE id = ? AND user_id = ? AND status = ?`,
+		percent, commitmentID, userID, model.CommitmentActive)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("active commitment not found")
+	}
+	return nil
+}
+
+// BreakCommitment cancels an active commitment. Saved points return to the
+// user's spendable balance via a goal_break ledger entry.
+func (s *Store) BreakCommitment(ctx context.Context, userID, commitmentID int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var ownerID int64
+	var status string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT user_id, status FROM reward_commitments WHERE id = ?`,
+		commitmentID).Scan(&ownerID, &status); err != nil {
+		return fmt.Errorf("commitment not found")
+	}
+	if ownerID != userID {
+		return fmt.Errorf("commitment not owned by user")
+	}
+	if status != model.CommitmentActive {
+		return fmt.Errorf("commitment is not active")
+	}
+
+	var saved int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+		 WHERE reference_id = ? AND reason IN (?, ?)`,
+		commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+		return err
+	}
+	if saved > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, 'cancelled')`,
+			userID, saved, model.ReasonGoalBreak, commitmentID); err != nil {
+			return err
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE reward_commitments SET status = ?, cancelled_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		model.CommitmentCancelled, commitmentID); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// applyAutoContributeTx auto-routes a fraction of a chore credit into the
+// user's active commitment, capped at the commitment's remaining target. A
+// no-op when there's no active commitment, percent is zero, or the
+// commitment is already fully funded.
+func (s *Store) applyAutoContributeTx(ctx context.Context, tx *sql.Tx, userID, completionID int64, creditAmount int) error {
+	if creditAmount <= 0 {
+		return nil
+	}
+	var commitmentID int64
+	var pct int
+	var target int
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, auto_contribute_percent, target_cost FROM reward_commitments
+		 WHERE user_id = ? AND status = ?`,
+		userID, model.CommitmentActive).Scan(&commitmentID, &pct, &target)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if pct <= 0 {
+		return nil
+	}
+
+	var saved int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+		 WHERE reference_id = ? AND reason IN (?, ?)`,
+		commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+		return err
+	}
+	remaining := target - saved
+	if remaining <= 0 {
+		return nil
+	}
+	contribution := creditAmount * pct / 100
+	if contribution <= 0 {
+		return nil
+	}
+	if contribution > remaining {
+		contribution = remaining
+	}
+
+	note := fmt.Sprintf("auto:completion:%d", completionID)
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+		 VALUES (?, ?, ?, ?, ?)`,
+		userID, -contribution, model.ReasonCommitToGoal, commitmentID, note)
+	return err
+}
+
+// reverseAutoContributeTx reverses any auto-contributions tied to this
+// completion if their commitment is still active. Idempotent: looks for a
+// previously emitted reversal note and skips work it already did.
+func (s *Store) reverseAutoContributeTx(ctx context.Context, tx *sql.Tx, userID, completionID int64) error {
+	autoNote := fmt.Sprintf("auto:completion:%d", completionID)
+	revertNote := fmt.Sprintf("auto_revert:completion:%d", completionID)
+
+	rows, err := tx.QueryContext(ctx,
+		`SELECT pt.reference_id, -pt.amount
+		 FROM point_transactions pt
+		 JOIN reward_commitments rc ON rc.id = pt.reference_id
+		 WHERE pt.user_id = ?
+		   AND pt.reason = ?
+		   AND pt.note = ?
+		   AND rc.status = ?
+		   AND NOT EXISTS (
+			 SELECT 1 FROM point_transactions p2
+			 WHERE p2.reason = ? AND p2.reference_id = pt.reference_id AND p2.note = ?
+		   )`,
+		userID, model.ReasonCommitToGoal, autoNote, model.CommitmentActive,
+		model.ReasonGoalBreak, revertNote)
+	if err != nil {
+		return err
+	}
+	type pair struct {
+		commitmentID int64
+		amount       int
+	}
+	var pairs []pair
+	for rows.Next() {
+		var p pair
+		if err := rows.Scan(&p.commitmentID, &p.amount); err != nil {
+			rows.Close()
+			return err
+		}
+		pairs = append(pairs, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, p := range pairs {
+		if p.amount <= 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, ?)`,
+			userID, p.amount, model.ReasonGoalBreak, p.commitmentID, revertNote); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // --- Streaks ---
@@ -1175,6 +1654,64 @@ func (s *Store) UndoRedemption(ctx context.Context, redemptionID int64) error {
 		redemptionID)
 	if err != nil {
 		return err
+	}
+
+	// If this redemption settled a commitment, undo that side too: drop the
+	// goal_break we emitted at redeem time and reactivate the commitment so
+	// the saved points sit in the goal again. We identify the commitment by
+	// the surviving commit_to_goal rows for (this user, this reward).
+	var commitmentID int64
+	err = tx.QueryRowContext(ctx,
+		`SELECT id FROM reward_commitments
+		 WHERE user_id = ? AND reward_id = ? AND status = ?`,
+		userID, rewardID, model.CommitmentRedeemed).Scan(&commitmentID)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if commitmentID != 0 {
+		// Drop the redemption-time goal_break so the saved points sit in the
+		// commitment again, and try to flip the commitment back to active.
+		// If the kid started a new active commitment in the meantime we can't
+		// have two actives, so we leave the old one redeemed and just refund
+		// — the kid keeps the reward's value as spendable points.
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM point_transactions
+			 WHERE reason = ? AND reference_id = ? AND note = 'redeemed via commitment'`,
+			model.ReasonGoalBreak, commitmentID); err != nil {
+			return err
+		}
+		var otherActive int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(1) FROM reward_commitments WHERE user_id = ? AND status = ? AND id != ?`,
+			userID, model.CommitmentActive, commitmentID).Scan(&otherActive); err != nil {
+			return err
+		}
+		if otherActive == 0 {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE reward_commitments SET status = ?, redeemed_at = NULL WHERE id = ?`,
+				model.CommitmentActive, commitmentID); err != nil {
+				return err
+			}
+		} else {
+			// Another commitment is active — emit a goal_break to release the
+			// original saved points back to spendable instead of resurrecting
+			// the goal, so the ledger doesn't claim points are still saved.
+			var saved int
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+				 WHERE reference_id = ? AND reason IN (?, ?)`,
+				commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+				return err
+			}
+			if saved > 0 {
+				if _, err := tx.ExecContext(ctx,
+					`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+					 VALUES (?, ?, ?, ?, 'undo redemption: another goal active')`,
+					userID, saved, model.ReasonGoalBreak, commitmentID); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	// Restore stock if the reward has limited stock

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2458,3 +2458,250 @@ func TestNullIdempotencyKeysAreNotUnique(t *testing.T) {
 		t.Errorf("expected 2 chore-credit rows with NULL keys, got %d", creditCount)
 	}
 }
+
+// ===== Reward Commitments =====
+
+func TestCommitmentManualSaveAndRedeem(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+
+	// Big-ticket reward.
+	reward := &model.Reward{Name: "LEGO set", Cost: 500, Active: true, CreatedBy: parent.ID}
+	if err := s.CreateReward(ctx, reward); err != nil {
+		t.Fatalf("CreateReward: %v", err)
+	}
+
+	// Seed the kid with 700 points via an admin adjust so we don't need a chore.
+	if err := s.AdminAdjustPoints(ctx, kid.ID, 700, "test seed"); err != nil {
+		t.Fatalf("AdminAdjustPoints: %v", err)
+	}
+
+	c, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 0)
+	if err != nil {
+		t.Fatalf("CreateCommitment: %v", err)
+	}
+	if c.TargetCost != 500 {
+		t.Errorf("expected target_cost=500, got %d", c.TargetCost)
+	}
+	if c.AmountSaved != 0 {
+		t.Errorf("expected amount_saved=0 on fresh commitment, got %d", c.AmountSaved)
+	}
+
+	// A second active commitment for the same kid should be rejected.
+	if _, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 0); err != store.ErrActiveCommitmentExists {
+		t.Errorf("expected ErrActiveCommitmentExists, got %v", err)
+	}
+
+	// Contribute 200 manually. Spendable should drop, saved should rise.
+	if err := s.ContributeToCommitment(ctx, kid.ID, c.ID, 200); err != nil {
+		t.Fatalf("ContributeToCommitment 200: %v", err)
+	}
+	bal, _ := s.GetPointBalance(ctx, kid.ID)
+	if bal != 500 {
+		t.Errorf("expected spendable 500 after 200 contribution, got %d", bal)
+	}
+	c, err = s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if err != nil || c == nil {
+		t.Fatalf("GetActiveCommitmentForUser: %v / %v", err, c)
+	}
+	if c.AmountSaved != 200 {
+		t.Errorf("expected amount_saved=200, got %d", c.AmountSaved)
+	}
+
+	// Try to redeem before fully funded — should fail.
+	if _, err := s.RedeemReward(ctx, kid.ID, reward.ID); err == nil {
+		t.Errorf("expected redeem to fail before commitment is fully funded")
+	}
+
+	// Top up to target (300 more) — store should cap if asked for too much.
+	if err := s.ContributeToCommitment(ctx, kid.ID, c.ID, 1000); err != nil {
+		t.Fatalf("ContributeToCommitment top-up: %v", err)
+	}
+	c, _ = s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if c.AmountSaved != 500 {
+		t.Errorf("expected saved capped at 500, got %d", c.AmountSaved)
+	}
+	bal, _ = s.GetPointBalance(ctx, kid.ID)
+	if bal != 200 {
+		t.Errorf("expected spendable 200 after full save, got %d", bal)
+	}
+
+	// Redeem now — should mark commitment redeemed and net spendable change to -500 across the
+	// whole flow (700 seeded → 200 spendable + 500 saved → 200 spendable + 0 saved + 1 redemption).
+	red, err := s.RedeemReward(ctx, kid.ID, reward.ID)
+	if err != nil {
+		t.Fatalf("RedeemReward: %v", err)
+	}
+	if red.PointsSpent != 500 {
+		t.Errorf("expected points_spent=500, got %d", red.PointsSpent)
+	}
+	bal, _ = s.GetPointBalance(ctx, kid.ID)
+	if bal != 200 {
+		t.Errorf("expected spendable 200 after redemption (unchanged), got %d", bal)
+	}
+	if got, _ := s.GetActiveCommitmentForUser(ctx, kid.ID); got != nil {
+		t.Errorf("expected no active commitment after redeem, got %+v", got)
+	}
+}
+
+func TestCommitmentBreakReturnsSavedToSpendable(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+	reward := &model.Reward{Name: "Trip", Cost: 100, Active: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	s.AdminAdjustPoints(ctx, kid.ID, 80, "seed")
+
+	c, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 0)
+	if err != nil {
+		t.Fatalf("CreateCommitment: %v", err)
+	}
+	if err := s.ContributeToCommitment(ctx, kid.ID, c.ID, 60); err != nil {
+		t.Fatalf("ContributeToCommitment: %v", err)
+	}
+
+	bal, _ := s.GetPointBalance(ctx, kid.ID)
+	if bal != 20 {
+		t.Errorf("expected spendable 20 after committing 60, got %d", bal)
+	}
+
+	if err := s.BreakCommitment(ctx, kid.ID, c.ID); err != nil {
+		t.Fatalf("BreakCommitment: %v", err)
+	}
+	bal, _ = s.GetPointBalance(ctx, kid.ID)
+	if bal != 80 {
+		t.Errorf("expected spendable 80 after break, got %d", bal)
+	}
+	if got, _ := s.GetActiveCommitmentForUser(ctx, kid.ID); got != nil {
+		t.Errorf("expected no active commitment after break, got %+v", got)
+	}
+	// A new commitment should now be allowed.
+	if _, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 0); err != nil {
+		t.Errorf("expected to be able to create a new commitment, got %v", err)
+	}
+}
+
+func TestAutoContributeOnChoreCredit(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+	reward := &model.Reward{Name: "Bike", Cost: 1000, Active: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+
+	c, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 25)
+	if err != nil {
+		t.Fatalf("CreateCommitment: %v", err)
+	}
+
+	// Simulate a chore completion paying 40 points. 25% should auto-contribute.
+	chore := createTestChore(t, s, "Big chore", 40, parent.ID)
+	cs := createTestSchedule(t, s, chore.ID, kid.ID, 1)
+	cc := &model.ChoreCompletion{ChoreScheduleID: cs.ID, CompletedBy: kid.ID, Status: model.StatusApproved, CompletionDate: "2026-05-06"}
+	if err := s.CompleteChore(ctx, cc); err != nil {
+		t.Fatalf("CompleteChore: %v", err)
+	}
+	if err := s.CreditChorePoints(ctx, kid.ID, cc.ID, 40); err != nil {
+		t.Fatalf("CreditChorePoints: %v", err)
+	}
+
+	bal, _ := s.GetPointBalance(ctx, kid.ID)
+	if bal != 30 {
+		t.Errorf("expected spendable 30 (40 credit - 10 auto), got %d", bal)
+	}
+	got, err := s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetActiveCommitmentForUser: %v / %v", err, got)
+	}
+	if got.AmountSaved != 10 {
+		t.Errorf("expected amount_saved=10 (25%% of 40), got %d", got.AmountSaved)
+	}
+
+	// Uncomplete the chore — both the credit and the auto-contribution should reverse.
+	if err := s.DebitChorePoints(ctx, kid.ID, cc.ID, 40); err != nil {
+		t.Fatalf("DebitChorePoints: %v", err)
+	}
+	bal, _ = s.GetPointBalance(ctx, kid.ID)
+	if bal != 0 {
+		t.Errorf("expected spendable 0 after uncomplete, got %d", bal)
+	}
+	got, _ = s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if got.AmountSaved != 0 {
+		t.Errorf("expected amount_saved=0 after auto-revert, got %d", got.AmountSaved)
+	}
+
+	// Idempotency: calling DebitChorePoints again must not over-credit savings back.
+	if err := s.DebitChorePoints(ctx, kid.ID, cc.ID, 40); err != nil {
+		t.Fatalf("DebitChorePoints again: %v", err)
+	}
+	got, _ = s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if got.AmountSaved != 0 {
+		t.Errorf("expected amount_saved still 0 after duplicate uncomplete, got %d", got.AmountSaved)
+	}
+	_ = c
+}
+
+func TestAutoContributeCapsAtTargetCost(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+	reward := &model.Reward{Name: "Sticker", Cost: 5, Active: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	c, _ := s.CreateCommitment(ctx, kid.ID, reward.ID, 100)
+
+	chore := createTestChore(t, s, "Huge chore", 100, parent.ID)
+	cs := createTestSchedule(t, s, chore.ID, kid.ID, 1)
+	cc := &model.ChoreCompletion{ChoreScheduleID: cs.ID, CompletedBy: kid.ID, Status: model.StatusApproved, CompletionDate: "2026-05-06"}
+	s.CompleteChore(ctx, cc)
+	if err := s.CreditChorePoints(ctx, kid.ID, cc.ID, 100); err != nil {
+		t.Fatalf("CreditChorePoints: %v", err)
+	}
+
+	got, _ := s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if got.AmountSaved != 5 {
+		t.Errorf("expected auto-contribute capped at target_cost 5, got %d", got.AmountSaved)
+	}
+	bal, _ := s.GetPointBalance(ctx, kid.ID)
+	if bal != 95 {
+		t.Errorf("expected spendable 95 after 5 was siphoned, got %d", bal)
+	}
+	_ = c
+}
+
+func TestCommitmentSnapshotsTargetCost(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+	reward := &model.Reward{Name: "Toy", Cost: 100, Active: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+
+	c, err := s.CreateCommitment(ctx, kid.ID, reward.ID, 0)
+	if err != nil {
+		t.Fatalf("CreateCommitment: %v", err)
+	}
+	if c.TargetCost != 100 {
+		t.Errorf("expected snapshotted target=100, got %d", c.TargetCost)
+	}
+
+	// Admin raises the price after the kid started saving.
+	reward.Cost = 200
+	if err := s.UpdateReward(ctx, reward); err != nil {
+		t.Fatalf("UpdateReward: %v", err)
+	}
+
+	// Refetch commitment — target_cost should still be the snapshotted value.
+	got, _ := s.GetActiveCommitmentForUser(ctx, kid.ID)
+	if got.TargetCost != 100 {
+		t.Errorf("expected target_cost still 100 (snapshotted), got %d", got.TargetCost)
+	}
+}

--- a/migrations/013_reward_commitments.down.sql
+++ b/migrations/013_reward_commitments.down.sql
@@ -1,0 +1,44 @@
+-- Drop commitment-related ledger rows so the narrowed CHECK on the rebuilt
+-- point_transactions table accepts the surviving rows. Dropping them is the
+-- right call here: a commit/break pair is a transfer between buckets, so
+-- removing both leaves the kid's total balance unchanged.
+DELETE FROM point_transactions
+    WHERE reason IN ('commit_to_goal', 'goal_break');
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE point_transactions_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount INTEGER NOT NULL,
+    reason TEXT NOT NULL CHECK (reason IN (
+        'chore_complete', 'chore_uncomplete', 'reward_redeem',
+        'streak_bonus', 'admin_adjust', 'expiry_penalty',
+        'points_decay', 'missed_chore'
+    )),
+    reference_id INTEGER,
+    note TEXT NOT NULL DEFAULT '',
+    idempotency_key TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO point_transactions_new
+    (id, user_id, amount, reason, reference_id, note, idempotency_key, created_at)
+SELECT
+    id, user_id, amount, reason, reference_id, note, idempotency_key, created_at
+FROM point_transactions;
+
+DROP TABLE point_transactions;
+ALTER TABLE point_transactions_new RENAME TO point_transactions;
+
+CREATE INDEX idx_point_tx_user ON point_transactions(user_id);
+CREATE INDEX idx_point_tx_ref ON point_transactions(reason, reference_id);
+CREATE UNIQUE INDEX idx_point_tx_idempotency_key
+    ON point_transactions(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+PRAGMA foreign_keys = ON;
+
+DROP INDEX IF EXISTS idx_reward_commitments_user;
+DROP INDEX IF EXISTS idx_reward_commitments_one_active;
+DROP TABLE IF EXISTS reward_commitments;

--- a/migrations/013_reward_commitments.up.sql
+++ b/migrations/013_reward_commitments.up.sql
@@ -1,0 +1,76 @@
+-- Reward commitments: lets a kid earmark points toward a chosen reward and
+-- watch progress, instead of being tempted to spend their balance on cheaper
+-- rewards. Implemented as a "soft" commitment: committed points are debited
+-- from the kid's spendable balance via the existing point_transactions ledger
+-- (reason='commit_to_goal'), and can be returned to spendable by an admin
+-- breaking the goal (reason='goal_break').
+--
+-- Spendable balance = SUM(point_transactions.amount) for the user, which
+-- naturally excludes points sitting in an active commitment. The "amount
+-- saved toward goal" is derived from the same ledger by summing rows that
+-- reference a specific commitment.
+--
+-- One active commitment per user keeps the UX simple for younger kids; the
+-- partial UNIQUE index enforces it. Redeemed/cancelled rows stay around for
+-- history.
+
+CREATE TABLE reward_commitments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    reward_id INTEGER NOT NULL REFERENCES rewards(id),
+    target_cost INTEGER NOT NULL CHECK (target_cost > 0),
+    auto_contribute_percent INTEGER NOT NULL DEFAULT 0
+        CHECK (auto_contribute_percent BETWEEN 0 AND 100),
+    status TEXT NOT NULL CHECK (status IN ('active', 'redeemed', 'cancelled'))
+        DEFAULT 'active',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    redeemed_at DATETIME,
+    cancelled_at DATETIME
+);
+
+CREATE UNIQUE INDEX idx_reward_commitments_one_active
+    ON reward_commitments(user_id)
+    WHERE status = 'active';
+
+CREATE INDEX idx_reward_commitments_user
+    ON reward_commitments(user_id);
+
+-- Widen the point_transactions.reason CHECK to accept the two new ledger
+-- reasons used by the commitment flow:
+--   * commit_to_goal  - kid moves points from spendable -> committed
+--   * goal_break      - parent/kid cancels a commitment, points return
+-- SQLite doesn't support ALTER CHECK in place, so we rebuild the table.
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE point_transactions_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount INTEGER NOT NULL,
+    reason TEXT NOT NULL CHECK (reason IN (
+        'chore_complete', 'chore_uncomplete', 'reward_redeem',
+        'streak_bonus', 'admin_adjust', 'expiry_penalty',
+        'points_decay', 'missed_chore',
+        'commit_to_goal', 'goal_break'
+    )),
+    reference_id INTEGER,
+    note TEXT NOT NULL DEFAULT '',
+    idempotency_key TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO point_transactions_new
+    (id, user_id, amount, reason, reference_id, note, idempotency_key, created_at)
+SELECT
+    id, user_id, amount, reason, reference_id, note, idempotency_key, created_at
+FROM point_transactions;
+
+DROP TABLE point_transactions;
+ALTER TABLE point_transactions_new RENAME TO point_transactions;
+
+CREATE INDEX idx_point_tx_user ON point_transactions(user_id);
+CREATE INDEX idx_point_tx_ref ON point_transactions(reason, reference_id);
+CREATE UNIQUE INDEX idx_point_tx_idempotency_key
+    ON point_transactions(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+PRAGMA foreign_keys = ON;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { User, ScheduledChore, Chore, ChoreSchedule, PointsData, PointBalance, PendingCompletion, Reward, RewardAssignment, RewardRedemption, RedemptionHistory, UserStreakData, StreakRewardItem, ChoreTrigger, Webhook, WebhookDelivery, UserDecayConfig, APIToken } from './types';
+import type { User, ScheduledChore, Chore, ChoreSchedule, PointsData, PointBalance, PendingCompletion, Reward, RewardAssignment, RewardRedemption, RewardCommitment, RedemptionHistory, UserStreakData, StreakRewardItem, ChoreTrigger, Webhook, WebhookDelivery, UserDecayConfig, APIToken } from './types';
 
 const API_BASE = '/api';
 
@@ -233,6 +233,26 @@ export const api = {
     redeem: (id: number) => fetchWithAuth<RewardRedemption>(`/rewards/${id}/redeem`, { method: 'POST' }),
     listRedemptions: (userId: number) => fetchWithAuth<RedemptionHistory[]>(`/users/${userId}/redemptions`),
     undoRedemption: (redemptionId: number) => fetchWithAuth(`/redemptions/${redemptionId}`, { method: 'DELETE' }),
+  },
+  commitments: {
+    listForUser: (userId: number) => fetchWithAuth<RewardCommitment[]>(`/users/${userId}/commitments`),
+    commit: (rewardId: number, autoContributePercent: number) =>
+      fetchWithAuth<RewardCommitment>(`/rewards/${rewardId}/commit`, {
+        method: 'POST',
+        body: JSON.stringify({ auto_contribute_percent: autoContributePercent }),
+      }),
+    contribute: (commitmentId: number, amount: number) =>
+      fetchWithAuth<RewardCommitment>(`/commitments/${commitmentId}/contribute`, {
+        method: 'POST',
+        body: JSON.stringify({ amount }),
+      }),
+    setAutoContribute: (commitmentId: number, percent: number) =>
+      fetchWithAuth<RewardCommitment>(`/commitments/${commitmentId}/auto-contribute`, {
+        method: 'PUT',
+        body: JSON.stringify({ percent }),
+      }),
+    break: (commitmentId: number) =>
+      fetchWithAuth(`/commitments/${commitmentId}`, { method: 'DELETE' }),
   },
   streaks: {
     getForUser: (userId: number) => fetchWithAuth<UserStreakData>(`/users/${userId}/streak`),

--- a/web/src/pages/Dashboard.module.css
+++ b/web/src/pages/Dashboard.module.css
@@ -1204,6 +1204,201 @@
   padding: 1rem 1.25rem;
 }
 
+/* --- Goal / Commitment --- */
+
+.goalCard {
+  background: linear-gradient(135deg, rgba(168, 85, 247, 0.12), rgba(236, 72, 153, 0.08));
+  border: 1px solid rgba(168, 85, 247, 0.25);
+  border-radius: var(--radius-card);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.goalHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.goalIcon {
+  font-size: 1.75rem;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.goalTitleBlock {
+  flex: 1;
+  min-width: 0;
+}
+
+.goalLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.goalName {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.goalAmounts {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.goalAmounts strong {
+  color: var(--text-primary);
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.goalProgressTrack {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.goalProgressFill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-purple), var(--accent-blue));
+  transition: width 0.4s ease-out;
+}
+
+.goalProgressFillDone {
+  background: linear-gradient(90deg, #22c55e, #16a34a);
+}
+
+.goalActions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.goalBtn {
+  flex: 1;
+  min-width: 110px;
+  padding: 0.55rem 0.9rem;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.goalBtnPrimary {
+  background: linear-gradient(135deg, var(--accent-purple), var(--accent-blue));
+  color: white;
+  border-color: transparent;
+}
+
+.goalBtnDanger {
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.25);
+}
+
+.goalAuto {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.goalAutoLabel {
+  white-space: nowrap;
+}
+
+.goalAutoSlider {
+  flex: 1;
+  accent-color: var(--accent-purple);
+}
+
+.goalAutoValue {
+  min-width: 2.5rem;
+  text-align: right;
+  color: var(--text-primary);
+  font-weight: 800;
+}
+
+.goalContributeRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.goalContributeInput {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.saveTowardBtn {
+  flex-shrink: 0;
+  padding: 0.55rem 0.85rem;
+  border-radius: 12px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  background: rgba(168, 85, 247, 0.12);
+  color: #c4b5fd;
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.saveTowardBtn:active {
+  transform: scale(0.96);
+}
+
+.rewardActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.goalBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #c4b5fd;
+  background: rgba(168, 85, 247, 0.15);
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+}
+
 .rewardsBalanceIcon { color: var(--accent-blue); }
 
 .rewardsBalanceAmount {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '../ThemeContext';
 import { api, APIError } from '../api';
 import type { ScheduledChore, UserStreakData, PointsData, Reward, RedemptionHistory, Theme } from '../types';
 import styles from './Dashboard.module.css';
-import { CheckCircle, Clock, Calendar, Star, LogOut, LayoutDashboard, Lock, KeyRound, Flame, Trophy, Zap, Gift, ShoppingBag, Palette, ShieldCheck, CircleCheck, Sparkles, Swords, Scroll, Coins, Rocket, Orbit, Telescope, TreePine, Sprout, Leaf, X, Loader2, Volume2, VolumeX, Undo2, Camera, Copy, Users } from 'lucide-react';
+import { CheckCircle, Clock, Calendar, Star, LogOut, LayoutDashboard, Lock, KeyRound, Flame, Trophy, Zap, Gift, ShoppingBag, Palette, ShieldCheck, CircleCheck, Sparkles, Swords, Scroll, Coins, Rocket, Orbit, Telescope, TreePine, Sprout, Leaf, X, Loader2, Volume2, VolumeX, Undo2, Camera, Copy, Users, Target, PiggyBank, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import confetti from 'canvas-confetti';
@@ -178,6 +178,10 @@ export const Dashboard: React.FC = () => {
   const [redemptions, setRedemptions] = useState<RedemptionHistory[]>([]);
   const [redeemingId, setRedeemingId] = useState<number | null>(null);
   const [redeemedId, setRedeemedId] = useState<number | null>(null);
+  const [savingTowardId, setSavingTowardId] = useState<number | null>(null);
+  const [contributeAmount, setContributeAmount] = useState<string>('');
+  const [contributing, setContributing] = useState(false);
+  const [breakingGoal, setBreakingGoal] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   // Per-schedule-id "request in flight" flag. Prevents double-POSTs when a
   // kid double-taps a chore tile (common on touchscreens), and lets us grey
@@ -348,12 +352,14 @@ export const Dashboard: React.FC = () => {
   };
 
   const handleRedeem = async (reward: Reward) => {
-    if (!pointsData || pointsData.balance < reward.effective_cost) return;
+    if (!pointsData) return;
+    const commitment = pointsData.active_commitment;
+    const isCommittedReward = commitment && commitment.reward_id === reward.id;
+    if (!isCommittedReward && pointsData.balance < reward.effective_cost) return;
+    if (isCommittedReward && commitment.amount_saved < commitment.target_cost) return;
     setRedeemingId(reward.id);
     try {
       await api.rewards.redeem(reward.id);
-      // Optimistically update balance so it feels instant
-      setPointsData(prev => prev ? { ...prev, balance: prev.balance - reward.effective_cost } : prev);
       setRedeemingId(null);
       setRedeemedId(reward.id);
       confetti({
@@ -365,13 +371,88 @@ export const Dashboard: React.FC = () => {
       playComplete();
       if (navigator.vibrate) navigator.vibrate(50);
       showToast(`${reward.icon || '🎁'} ${reward.name} redeemed!`);
-      // Refresh real data in background
       await Promise.all([loadExtras(), loadRewards()]);
       setTimeout(() => setRedeemedId(null), 2000);
     } catch (e) {
       console.error('Redeem error:', e);
       setRedeemingId(null);
       showToast('Redemption failed — try again');
+    }
+  };
+
+  const handleSaveToward = async (reward: Reward) => {
+    if (!pointsData) return;
+    if (pointsData.active_commitment) {
+      showToast('You already have an active goal — finish or change it first');
+      return;
+    }
+    setSavingTowardId(reward.id);
+    try {
+      await api.commitments.commit(reward.id, 0);
+      showToast(`Saving toward ${reward.icon || '🎁'} ${reward.name}!`);
+      await loadExtras();
+    } catch (e) {
+      console.error('Save toward error:', e);
+      const msg = e instanceof APIError ? e.message : 'Could not start saving — try again';
+      showToast(msg);
+    } finally {
+      setSavingTowardId(null);
+    }
+  };
+
+  const handleContribute = async () => {
+    if (!pointsData?.active_commitment) return;
+    const amount = parseInt(contributeAmount, 10);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      showToast('Enter a number of points to add');
+      return;
+    }
+    if (amount > pointsData.balance) {
+      showToast(`You only have ${pointsData.balance} spendable`);
+      return;
+    }
+    setContributing(true);
+    try {
+      await api.commitments.contribute(pointsData.active_commitment.id, amount);
+      setContributeAmount('');
+      await loadExtras();
+      showToast(`Saved ${amount} more!`);
+    } catch (e) {
+      console.error('Contribute error:', e);
+      const msg = e instanceof APIError ? e.message : 'Could not save — try again';
+      showToast(msg);
+    } finally {
+      setContributing(false);
+    }
+  };
+
+  const handleSetAutoContribute = async (percent: number) => {
+    if (!pointsData?.active_commitment) return;
+    // Optimistic so the slider feels responsive.
+    setPointsData(prev => prev && prev.active_commitment
+      ? { ...prev, active_commitment: { ...prev.active_commitment, auto_contribute_percent: percent } }
+      : prev);
+    try {
+      await api.commitments.setAutoContribute(pointsData.active_commitment.id, percent);
+    } catch (e) {
+      console.error('Auto-contribute error:', e);
+      await loadExtras();
+    }
+  };
+
+  const handleBreakCommitment = async () => {
+    if (!pointsData?.active_commitment) return;
+    if (!window.confirm('Stop saving? Your saved points will go back to your spendable balance.')) return;
+    setBreakingGoal(true);
+    try {
+      await api.commitments.break(pointsData.active_commitment.id);
+      await loadExtras();
+      showToast('Goal cancelled — points are back in your balance');
+    } catch (e) {
+      console.error('Break commitment error:', e);
+      showToast('Could not cancel goal — try again');
+    } finally {
+      setBreakingGoal(false);
     }
   };
 
@@ -822,16 +903,111 @@ export const Dashboard: React.FC = () => {
     );
   };
 
+  const renderGoalCard = () => {
+    const commitment = pointsData?.active_commitment;
+    if (!commitment) return null;
+    const pct = Math.min(100, Math.round((commitment.amount_saved / commitment.target_cost) * 100));
+    const fullyFunded = commitment.amount_saved >= commitment.target_cost;
+    const remaining = Math.max(0, commitment.target_cost - commitment.amount_saved);
+    return (
+      <div className={styles.goalCard}>
+        <div className={styles.goalHeader}>
+          <div className={styles.goalIcon}>{commitment.reward_icon || '🎯'}</div>
+          <div className={styles.goalTitleBlock}>
+            <div className={styles.goalLabel}>Saving toward</div>
+            <div className={styles.goalName}>{commitment.reward_name}</div>
+          </div>
+          {fullyFunded && <span className={styles.goalBadge}>Ready!</span>}
+        </div>
+        <div className={styles.goalAmounts}>
+          <span><strong>{commitment.amount_saved}</strong> / {commitment.target_cost} pts</span>
+          <span>{fullyFunded ? 'Fully funded 🎉' : `${remaining} to go`}</span>
+        </div>
+        <div className={styles.goalProgressTrack}>
+          <div
+            className={clsx(styles.goalProgressFill, fullyFunded && styles.goalProgressFillDone)}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+
+        <div className={styles.goalAuto}>
+          <PiggyBank size={14} />
+          <span className={styles.goalAutoLabel}>Auto-save</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={commitment.auto_contribute_percent}
+            onChange={e => handleSetAutoContribute(parseInt(e.target.value, 10))}
+            className={styles.goalAutoSlider}
+          />
+          <span className={styles.goalAutoValue}>{commitment.auto_contribute_percent}%</span>
+        </div>
+
+        {!fullyFunded && (
+          <div className={styles.goalContributeRow}>
+            <input
+              type="number"
+              min={1}
+              max={pointsData?.balance ?? 0}
+              placeholder={`Add points (max ${pointsData?.balance ?? 0})`}
+              value={contributeAmount}
+              onChange={e => setContributeAmount(e.target.value)}
+              className={styles.goalContributeInput}
+            />
+            <button
+              className={clsx(styles.goalBtn, styles.goalBtnPrimary)}
+              onClick={handleContribute}
+              disabled={contributing || !contributeAmount}
+              style={{ flex: '0 0 auto', minWidth: 90 }}
+            >
+              <Plus size={14} /> Save
+            </button>
+          </div>
+        )}
+
+        <div className={styles.goalActions}>
+          {fullyFunded && (
+            <button
+              className={clsx(styles.goalBtn, styles.goalBtnPrimary)}
+              onClick={() => {
+                const r = rewards.find(x => x.id === commitment.reward_id);
+                if (r) handleRedeem(r);
+              }}
+              disabled={redeemingId === commitment.reward_id}
+            >
+              <Gift size={14} /> Redeem now
+            </button>
+          )}
+          <button
+            className={clsx(styles.goalBtn, styles.goalBtnDanger)}
+            onClick={handleBreakCommitment}
+            disabled={breakingGoal}
+          >
+            <X size={14} /> Stop saving
+          </button>
+        </div>
+      </div>
+    );
+  };
+
   const renderRewardsView = () => {
     const balance = pointsData?.balance ?? 0;
+    const committed = pointsData?.committed ?? 0;
+    const commitment = pointsData?.active_commitment;
 
     return (
       <div className={styles.rewardsView}>
         <div className={styles.rewardsBalance}>
           <Star size={20} className={styles.rewardsBalanceIcon} />
           <span className={styles.rewardsBalanceAmount}>{balance}</span>
-          <span className={styles.rewardsBalanceLabel}>points available</span>
+          <span className={styles.rewardsBalanceLabel}>
+            spendable{committed > 0 ? ` · ${committed} saved` : ''}
+          </span>
         </div>
+
+        {renderGoalCard()}
 
         {rewards.length === 0 ? (
           <div className={styles.empty}>
@@ -842,15 +1018,22 @@ export const Dashboard: React.FC = () => {
         ) : (
           <div className={styles.rewardsGrid}>
             {rewards.map(reward => {
+              const isCommittedReward = !!(commitment && commitment.reward_id === reward.id);
               const canAfford = balance >= reward.effective_cost;
+              const fullyFunded = isCommittedReward && commitment!.amount_saved >= commitment!.target_cost;
               const outOfStock = reward.stock !== null && reward.stock !== undefined && reward.stock <= 0;
               const isRedeeming = redeemingId === reward.id;
+              const isSaving = savingTowardId === reward.id;
+              const showSaveToward = !commitment && reward.effective_cost > balance;
 
               return (
-                <div key={reward.id} className={clsx(styles.rewardCard, !canAfford && styles.rewardCardLocked)}>
+                <div key={reward.id} className={clsx(styles.rewardCard, !canAfford && !isCommittedReward && styles.rewardCardLocked)}>
                   {reward.icon && <div className={styles.rewardIcon}>{reward.icon}</div>}
                   <div className={styles.rewardInfo}>
-                    <h3 className={styles.rewardName}>{reward.name}</h3>
+                    <h3 className={styles.rewardName}>
+                      {reward.name}
+                      {isCommittedReward && <> <span className={styles.goalBadge}><Target size={10} /> goal</span></>}
+                    </h3>
                     {reward.description && (
                       <p className={styles.rewardDesc}>{reward.description}</p>
                     )}
@@ -865,17 +1048,38 @@ export const Dashboard: React.FC = () => {
                       )}
                     </div>
                   </div>
-                  <button
-                    className={clsx(
-                      styles.redeemBtn,
-                      canAfford && !outOfStock && styles.redeemBtnActive,
-                      redeemedId === reward.id && styles.redeemBtnSuccess
+                  <div className={styles.rewardActions}>
+                    <button
+                      className={clsx(
+                        styles.redeemBtn,
+                        ((isCommittedReward && fullyFunded) || (!isCommittedReward && canAfford)) && !outOfStock && styles.redeemBtnActive,
+                        redeemedId === reward.id && styles.redeemBtnSuccess
+                      )}
+                      disabled={(isCommittedReward ? !fullyFunded : !canAfford) || outOfStock || isRedeeming || redeemedId === reward.id}
+                      onClick={() => handleRedeem(reward)}
+                    >
+                      {redeemedId === reward.id
+                        ? <><CheckCircle size={14} /> Redeemed!</>
+                        : isRedeeming
+                          ? '...'
+                          : outOfStock
+                            ? 'Gone'
+                            : isCommittedReward
+                              ? (fullyFunded ? 'Redeem' : `${commitment!.amount_saved}/${commitment!.target_cost}`)
+                              : canAfford
+                                ? 'Redeem'
+                                : `Need ${reward.effective_cost - balance}`}
+                    </button>
+                    {showSaveToward && !outOfStock && (
+                      <button
+                        className={styles.saveTowardBtn}
+                        onClick={() => handleSaveToward(reward)}
+                        disabled={isSaving}
+                      >
+                        {isSaving ? '...' : <><Target size={12} /> Save toward</>}
+                      </button>
                     )}
-                    disabled={!canAfford || outOfStock || isRedeeming || redeemedId === reward.id}
-                    onClick={() => handleRedeem(reward)}
-                  >
-                    {redeemedId === reward.id ? <><CheckCircle size={14} /> Redeemed!</> : isRedeeming ? '...' : outOfStock ? 'Gone' : canAfford ? 'Redeem' : `Need ${reward.effective_cost - balance}`}
-                  </button>
+                  </div>
                 </div>
               );
             })}
@@ -971,6 +1175,38 @@ export const Dashboard: React.FC = () => {
       )}
     </div>
   );
+
+  // Lightweight banner that nudges the kid toward their goal from the daily
+  // view. Tap it to jump to the rewards tab where they can save more or
+  // redeem when fully funded.
+  const renderGoalBanner = () => {
+    const c = pointsData?.active_commitment;
+    if (!c) return null;
+    const pct = Math.min(100, Math.round((c.amount_saved / c.target_cost) * 100));
+    const fullyFunded = c.amount_saved >= c.target_cost;
+    return (
+      <div className={styles.goalCard} onClick={() => setView('rewards')} role="button" tabIndex={0}>
+        <div className={styles.goalHeader}>
+          <div className={styles.goalIcon}>{c.reward_icon || '🎯'}</div>
+          <div className={styles.goalTitleBlock}>
+            <div className={styles.goalLabel}>Saving toward</div>
+            <div className={styles.goalName}>{c.reward_name}</div>
+          </div>
+          {fullyFunded && <span className={styles.goalBadge}>Ready!</span>}
+        </div>
+        <div className={styles.goalAmounts}>
+          <span><strong>{c.amount_saved}</strong> / {c.target_cost} pts</span>
+          <span>{fullyFunded ? 'Tap to redeem 🎉' : `${c.target_cost - c.amount_saved} to go`}</span>
+        </div>
+        <div className={styles.goalProgressTrack}>
+          <div
+            className={clsx(styles.goalProgressFill, fullyFunded && styles.goalProgressFillDone)}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    );
+  };
 
   // Streak milestone banner
   const renderStreakBanner = () => {
@@ -1134,6 +1370,7 @@ export const Dashboard: React.FC = () => {
         <>
           {view === 'daily' && renderProgressBar()}
           {view === 'daily' && renderPointsSummary()}
+          {view === 'daily' && renderGoalBanner()}
           {view === 'daily' && renderStreakBanner()}
 
           <nav className={styles.nav}>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -245,14 +245,31 @@ export interface PointTransaction {
   id: number;
   user_id: number;
   amount: number;
-  reason: 'chore_complete' | 'chore_uncomplete' | 'reward_redeem' | 'streak_bonus' | 'admin_adjust' | 'expiry_penalty' | 'points_decay' | 'missed_chore';
+  reason: 'chore_complete' | 'chore_uncomplete' | 'reward_redeem' | 'streak_bonus' | 'admin_adjust' | 'expiry_penalty' | 'points_decay' | 'missed_chore' | 'commit_to_goal' | 'goal_break';
   reference_id?: number;
   note?: string;
   created_at: string;
 }
 
+export interface RewardCommitment {
+  id: number;
+  user_id: number;
+  reward_id: number;
+  reward_name?: string;
+  reward_icon?: string;
+  target_cost: number;
+  amount_saved: number;
+  auto_contribute_percent: number;
+  status: 'active' | 'redeemed' | 'cancelled';
+  created_at: string;
+  redeemed_at?: string;
+  cancelled_at?: string;
+}
+
 export interface PointsData {
   balance: number;
+  committed: number;
+  active_commitment: RewardCommitment | null;
   transactions: PointTransaction[];
 }
 


### PR DESCRIPTION
## Summary

Adds a "soft commitment" / piggy-bank flow so a kid can pick a reward and earmark points toward it instead of being tempted to spend their balance on cheaper rewards. Saved points are visually separated from spendable, with a kid-controllable auto-contribute slider for hands-off saving.

### How it works
- One **active commitment** per kid. A new table `reward_commitments` stores the snapshotted target cost (so admins raising a price doesn't punish the saver), an auto-contribute percent (0–100, kid-editable), and status (`active` / `redeemed` / `cancelled`).
- Saving and breaking ride the existing `point_transactions` ledger via two new reasons: `commit_to_goal` (kid → committed) and `goal_break` (committed → kid). `SUM(amount)` continues to be the spendable balance because committed points are already debited; the saved amount per goal is derived from the ledger.
- **Auto-contribute** is applied inside `CreditChorePoints` (now transactional) — when a chore credits the kid, a fraction of that credit is routed straight into the active goal, capped at the remaining target. `DebitChorePoints` reverses the auto-contribution if the commitment is still active and the reversal hasn't already been emitted.
- **Redeeming a goal-committed reward** first emits a `goal_break` to release saved points, then the normal `reward_redeem` debit, and marks the commitment redeemed. `UndoRedemption` reverses the dance and tries to reactivate the commitment when no other one is active.

### API
- `GET /api/users/{id}/points` now returns `balance` (spendable), `committed`, and `active_commitment`.
- `GET /api/users/{id}/commitments` — full history.
- `POST /api/rewards/{id}/commit` — start saving toward a reward.
- `POST /api/commitments/{id}/contribute` — manual contribution.
- `PUT /api/commitments/{id}/auto-contribute` — kid-controlled %.
- `DELETE /api/commitments/{id}` — cancel and refund saved points.

### UI (kid Dashboard)
- Rewards tab shows a goal card with a progress bar, "spendable / saved" split, auto-save slider, manual "+ save" input, and "stop saving" button. Cards for non-goal rewards now show a **"Save toward"** button when the reward is unaffordable and no goal is active.
- Daily view gets a tappable goal banner that jumps to the rewards tab.

### Bullets
- Soft commitment, kid-controllable auto-contribute, parent-undoable via existing redemption undo.
- Migration `013` adds the table and widens the `point_transactions.reason` CHECK; SQLite table-rebuild dance with rollback in the down migration.
- 5 new store-level tests cover manual save + redeem, break, auto-contribute, target-cost cap, and price-snapshot semantics.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `npx tsc --noEmit` and `npm run build` — clean
- [ ] Manual: kid creates a commitment, sets auto-contribute %, completes chores, watches the goal fill, redeems when funded, breaks a partial commitment and confirms refund
- [ ] Manual: admin raises a reward's price after a kid commits — goal target stays at the snapshotted cost
- [ ] Manual: parent uses existing "undo redemption" on a commitment-redeemed reward — points return correctly

https://claude.ai/code/session_01VJZ4BL7QrkW94LqpWNHpJR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJZ4BL7QrkW94LqpWNHpJR)_