### PR TITLE
Shareable rewards: family goals with per-kid contribution tracking

### DIFF
--- a/internal/api/points.go
+++ b/internal/api/points.go
@@ -23,23 +23,25 @@ func (h *PointsHandler) GetUserPoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// SUM(point_transactions.amount) is naturally the spendable balance:
-	// commit_to_goal entries already debit it. Surface "balance" as the
-	// spendable number the kid can spend on cheaper rewards, plus a separate
-	// "committed" total + the active commitment (if any) so the UI can show
-	// progress toward the saved goal.
+	// commit_to_goal entries already debit it. The kid can have one personal
+	// goal AND any number of shared family pools open at once — return them
+	// all so the UI can render a stack of goal cards.
 	balance, err := h.store.GetPointBalance(r.Context(), userID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get balance")
 		return
 	}
-	commitment, err := h.store.GetActiveCommitmentForUser(r.Context(), userID)
+	commitments, err := h.store.ListActiveCommitmentsForUser(r.Context(), userID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get commitment")
+		writeError(w, http.StatusInternalServerError, "failed to get commitments")
 		return
 	}
+	if commitments == nil {
+		commitments = []model.RewardCommitment{}
+	}
 	committed := 0
-	if commitment != nil {
-		committed = commitment.AmountSaved
+	for _, c := range commitments {
+		committed += c.AmountSaved
 	}
 	txs, err := h.store.ListPointTransactions(r.Context(), userID, 50)
 	if err != nil {
@@ -50,10 +52,10 @@ func (h *PointsHandler) GetUserPoints(w http.ResponseWriter, r *http.Request) {
 		txs = []model.PointTransaction{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"balance":           balance,
-		"committed":         committed,
-		"active_commitment": commitment,
-		"transactions":      txs,
+		"balance":            balance,
+		"committed":          committed,
+		"active_commitments": commitments,
+		"transactions":       txs,
 	})
 }
 

--- a/internal/api/rewards.go
+++ b/internal/api/rewards.go
@@ -49,6 +49,7 @@ func (h *RewardHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Icon        string `json:"icon"`
 		Cost        int    `json:"cost"`
 		Stock       *int   `json:"stock"`
+		Shareable   bool   `json:"shareable"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -66,6 +67,7 @@ func (h *RewardHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Cost:        req.Cost,
 		Stock:       req.Stock,
 		Active:      true,
+		Shareable:   req.Shareable,
 		CreatedBy:   user.ID,
 	}
 	if err := h.store.CreateReward(r.Context(), reward); err != nil {
@@ -93,6 +95,7 @@ func (h *RewardHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Cost        *int    `json:"cost"`
 		Stock       *int    `json:"stock"`
 		Active      *bool   `json:"active"`
+		Shareable   *bool   `json:"shareable"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -115,6 +118,9 @@ func (h *RewardHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Active != nil {
 		existing.Active = *req.Active
+	}
+	if req.Shareable != nil {
+		existing.Shareable = *req.Shareable
 	}
 	if err := h.store.UpdateReward(r.Context(), existing); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update reward")
@@ -292,7 +298,7 @@ func (h *RewardHandler) Contribute(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-	c, err := h.store.GetActiveCommitmentForUser(r.Context(), user.ID)
+	c, err := h.store.GetCommitment(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to reload commitment")
 		return
@@ -318,7 +324,7 @@ func (h *RewardHandler) SetAutoContribute(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-	c, err := h.store.GetActiveCommitmentForUser(r.Context(), user.ID)
+	c, err := h.store.GetCommitment(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to reload commitment")
 		return
@@ -338,4 +344,25 @@ func (h *RewardHandler) BreakCommitment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetSharedPool returns the up-to-date pool details: target, total saved,
+// and per-contributor breakdown for the leaderboard. Used by kids' clients
+// to refresh after a sibling adds points.
+func (h *RewardHandler) GetSharedPool(w http.ResponseWriter, r *http.Request) {
+	id, err := urlParamInt64(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid pool id")
+		return
+	}
+	pool, err := h.store.GetSharedPool(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load pool")
+		return
+	}
+	if pool == nil {
+		writeError(w, http.StatusNotFound, "pool not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, pool)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -89,6 +89,7 @@ func NewRouter(s *store.Store, dispatcher *webhook.Dispatcher) (*chi.Mux, *Chore
 			r.Post("/commitments/{id}/contribute", rewards.Contribute)
 			r.Put("/commitments/{id}/auto-contribute", rewards.SetAutoContribute)
 			r.Delete("/commitments/{id}", rewards.BreakCommitment)
+			r.Get("/pools/{id}", rewards.GetSharedPool)
 
 			// Admin-only routes
 			r.Group(func(r chi.Router) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -156,6 +156,7 @@ type Reward struct {
 	EffectiveCost int                `json:"effective_cost"` // per-user cost (may differ from base cost)
 	Stock         *int               `json:"stock,omitempty"`
 	Active        bool               `json:"active"`
+	Shareable     bool               `json:"shareable"`
 	CreatedBy     int64              `json:"created_by"`
 	CreatedAt     time.Time          `json:"created_at"`
 	Assignments   []RewardAssignment `json:"assignments,omitempty"`
@@ -179,19 +180,47 @@ type RewardRedemption struct {
 // RewardCommitment represents a kid earmarking points toward a chosen reward.
 // AmountSaved is derived from point_transactions referencing this commitment
 // and is populated by the store layer (not stored on the row itself).
+// SharedPoolID, when non-nil, marks this row as a kid's share of a pooled
+// family goal — Pool is populated for caller convenience.
 type RewardCommitment struct {
-	ID                    int64      `json:"id"`
-	UserID                int64      `json:"user_id"`
-	RewardID              int64      `json:"reward_id"`
-	RewardName            string     `json:"reward_name,omitempty"`
-	RewardIcon            string     `json:"reward_icon,omitempty"`
-	TargetCost            int        `json:"target_cost"`
-	AmountSaved           int        `json:"amount_saved"`
-	AutoContributePercent int        `json:"auto_contribute_percent"`
-	Status                string     `json:"status"`
-	CreatedAt             time.Time  `json:"created_at"`
-	RedeemedAt            *time.Time `json:"redeemed_at,omitempty"`
-	CancelledAt           *time.Time `json:"cancelled_at,omitempty"`
+	ID                    int64                 `json:"id"`
+	UserID                int64                 `json:"user_id"`
+	RewardID              int64                 `json:"reward_id"`
+	RewardName            string                `json:"reward_name,omitempty"`
+	RewardIcon            string                `json:"reward_icon,omitempty"`
+	TargetCost            int                   `json:"target_cost"`
+	AmountSaved           int                   `json:"amount_saved"`
+	AutoContributePercent int                   `json:"auto_contribute_percent"`
+	Status                string                `json:"status"`
+	SharedPoolID          *int64                `json:"shared_pool_id,omitempty"`
+	Pool                  *SharedCommitmentPool `json:"pool,omitempty"`
+	CreatedAt             time.Time             `json:"created_at"`
+	RedeemedAt            *time.Time            `json:"redeemed_at,omitempty"`
+	CancelledAt           *time.Time            `json:"cancelled_at,omitempty"`
+}
+
+// SharedCommitmentPool is the pooled save target multiple kids are
+// contributing to. AmountSaved is the sum across active contributors.
+type SharedCommitmentPool struct {
+	ID           int64             `json:"id"`
+	RewardID     int64             `json:"reward_id"`
+	RewardName   string            `json:"reward_name,omitempty"`
+	RewardIcon   string            `json:"reward_icon,omitempty"`
+	TargetCost   int               `json:"target_cost"`
+	AmountSaved  int               `json:"amount_saved"`
+	Status       string            `json:"status"`
+	Contributors []PoolContributor `json:"contributors,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	RedeemedAt   *time.Time        `json:"redeemed_at,omitempty"`
+}
+
+// PoolContributor is one kid's slice of a shared pool — populated for the UI
+// leaderboard ("You: 75, Alice: 120, Bob: 50").
+type PoolContributor struct {
+	UserID      int64  `json:"user_id"`
+	UserName    string `json:"user_name"`
+	AvatarURL   string `json:"avatar_url,omitempty"`
+	AmountSaved int    `json:"amount_saved"`
 }
 
 // --- Streaks ---

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -735,9 +735,9 @@ func (s *Store) AdminAdjustPoints(ctx context.Context, userID int64, amount int,
 
 func (s *Store) CreateReward(ctx context.Context, r *model.Reward) error {
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO rewards (name, description, icon, cost, stock, active, created_by)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		r.Name, r.Description, r.Icon, r.Cost, r.Stock, r.Active, r.CreatedBy)
+		`INSERT INTO rewards (name, description, icon, cost, stock, active, shareable, created_by)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.Name, r.Description, r.Icon, r.Cost, r.Stock, r.Active, boolToInt(r.Shareable), r.CreatedBy)
 	if err != nil {
 		return err
 	}
@@ -747,20 +747,21 @@ func (s *Store) CreateReward(ctx context.Context, r *model.Reward) error {
 
 func (s *Store) GetReward(ctx context.Context, id int64) (*model.Reward, error) {
 	r := &model.Reward{}
-	var active int
+	var active, shareable int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, name, description, icon, cost, stock, active, created_by, created_at
+		`SELECT id, name, description, icon, cost, stock, active, shareable, created_by, created_at
 		 FROM rewards WHERE id = ?`, id).
-		Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &active, &r.CreatedBy, &r.CreatedAt)
+		Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &active, &shareable, &r.CreatedBy, &r.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	r.Active = active == 1
+	r.Shareable = shareable == 1
 	return r, err
 }
 
 func (s *Store) ListRewards(ctx context.Context, activeOnly bool) ([]model.Reward, error) {
-	q := `SELECT id, name, description, icon, cost, stock, active, created_by, created_at FROM rewards`
+	q := `SELECT id, name, description, icon, cost, stock, active, shareable, created_by, created_at FROM rewards`
 	if activeOnly {
 		q += ` WHERE active = 1`
 	}
@@ -773,11 +774,12 @@ func (s *Store) ListRewards(ctx context.Context, activeOnly bool) ([]model.Rewar
 	var rewards []model.Reward
 	for rows.Next() {
 		var r model.Reward
-		var active int
-		if err := rows.Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &active, &r.CreatedBy, &r.CreatedAt); err != nil {
+		var active, shareable int
+		if err := rows.Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &active, &shareable, &r.CreatedBy, &r.CreatedAt); err != nil {
 			return nil, err
 		}
 		r.Active = active == 1
+		r.Shareable = shareable == 1
 		r.EffectiveCost = r.Cost
 		rewards = append(rewards, r)
 	}
@@ -789,7 +791,7 @@ func (s *Store) ListRewards(ctx context.Context, activeOnly bool) ([]model.Rewar
 // If it has assignments, only assigned users see it, with per-user cost.
 func (s *Store) ListRewardsForUser(ctx context.Context, userID int64) ([]model.Reward, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT r.id, r.name, r.description, r.icon, r.cost, r.stock, r.created_by, r.created_at,
+		SELECT r.id, r.name, r.description, r.icon, r.cost, r.stock, r.shareable, r.created_by, r.created_at,
 			ra.custom_cost
 		FROM rewards r
 		LEFT JOIN reward_assignments ra ON ra.reward_id = r.id AND ra.user_id = ?
@@ -808,11 +810,13 @@ func (s *Store) ListRewardsForUser(ctx context.Context, userID int64) ([]model.R
 	var rewards []model.Reward
 	for rows.Next() {
 		var r model.Reward
+		var shareable int
 		var customCost sql.NullInt64
-		if err := rows.Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &r.CreatedBy, &r.CreatedAt, &customCost); err != nil {
+		if err := rows.Scan(&r.ID, &r.Name, &r.Description, &r.Icon, &r.Cost, &r.Stock, &shareable, &r.CreatedBy, &r.CreatedAt, &customCost); err != nil {
 			return nil, err
 		}
 		r.Active = true
+		r.Shareable = shareable == 1
 		if customCost.Valid {
 			r.EffectiveCost = int(customCost.Int64)
 		} else {
@@ -884,10 +888,9 @@ func (s *Store) SetRewardAssignments(ctx context.Context, rewardID int64, assign
 }
 
 func (s *Store) UpdateReward(ctx context.Context, r *model.Reward) error {
-	active := boolToInt(r.Active)
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE rewards SET name=?, description=?, icon=?, cost=?, stock=?, active=? WHERE id=?`,
-		r.Name, r.Description, r.Icon, r.Cost, r.Stock, active, r.ID)
+		`UPDATE rewards SET name=?, description=?, icon=?, cost=?, stock=?, active=?, shareable=? WHERE id=?`,
+		r.Name, r.Description, r.Icon, r.Cost, r.Stock, boolToInt(r.Active), boolToInt(r.Shareable), r.ID)
 	return err
 }
 
@@ -906,10 +909,10 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 	// Get reward
 	var baseCost int
 	var stock sql.NullInt64
-	var active int
+	var active, shareable int
 	err = tx.QueryRowContext(ctx,
-		`SELECT cost, stock, active FROM rewards WHERE id = ?`, rewardID).
-		Scan(&baseCost, &stock, &active)
+		`SELECT cost, stock, active, shareable FROM rewards WHERE id = ?`, rewardID).
+		Scan(&baseCost, &stock, &active, &shareable)
 	if err != nil {
 		return nil, fmt.Errorf("reward not found")
 	}
@@ -941,7 +944,22 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 		}
 	}
 
-	// Determine effective cost (per-user override or base)
+	// Shareable rewards must be redeemed through their pool: anyone in the
+	// pool can hit redeem once it's fully funded, and each kid is debited
+	// only their contribution. This enforces the social contract — no kid
+	// alone shoulders the cost on a family goal.
+	if shareable == 1 {
+		out, err := s.redeemSharedPoolTx(ctx, tx, userID, rewardID, stock)
+		if err != nil {
+			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	// Determine effective cost (per-user override or base) for personal flow.
 	cost := baseCost
 	var customCost sql.NullInt64
 	tx.QueryRowContext(ctx,
@@ -951,28 +969,26 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 		cost = int(customCost.Int64)
 	}
 
-	// Look for an active commitment toward this reward. If one exists, the kid
-	// must have saved at least the snapshotted target before they can redeem;
-	// the saved points are still in the ledger as commit_to_goal debits, so we
-	// emit a goal_break to return them to spendable just before the normal
-	// reward_redeem debit. Net effect on the ledger is -target_cost, which is
-	// the same as a standard redemption — but the commitment row gets marked
-	// redeemed and any difference between target_cost and current cost flows
-	// to the kid (we redeem at the snapshotted target, not the current price).
+	// Look for an active personal commitment toward this reward. If one
+	// exists, the kid must have saved at least the snapshotted target before
+	// they can redeem; the saved points are still in the ledger as
+	// commit_to_goal debits, so we emit a goal_break to return them to
+	// spendable just before the normal reward_redeem debit. Net effect on the
+	// ledger is -target_cost, the same as a standard redemption — but the
+	// commitment row gets marked redeemed and the kid pays the snapshotted
+	// target, not the current price.
 	var commitmentID int64
 	var commitmentTarget int
 	commitmentRow := tx.QueryRowContext(ctx,
 		`SELECT id, target_cost FROM reward_commitments
-		 WHERE user_id = ? AND reward_id = ? AND status = ?`,
+		 WHERE user_id = ? AND reward_id = ? AND status = ? AND shared_pool_id IS NULL`,
 		userID, rewardID, model.CommitmentActive)
 	if err := commitmentRow.Scan(&commitmentID, &commitmentTarget); err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
 
 	if commitmentID != 0 {
-		// Honour the snapshotted target so price changes don't burn the saver.
 		cost = commitmentTarget
-
 		var saved int
 		err = tx.QueryRowContext(ctx,
 			`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
@@ -995,14 +1011,10 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 	if err != nil {
 		return nil, err
 	}
-	// When redeeming via a fully-funded commitment, the goal_break we're about
-	// to emit will return the saved points first, so spendable+saved must
-	// cover cost — saved >= cost is already verified above, so this passes.
 	if commitmentID == 0 && balance < cost {
 		return nil, fmt.Errorf("insufficient points (have %d, need %d)", balance, cost)
 	}
 
-	// Insert redemption
 	res, err := tx.ExecContext(ctx,
 		`INSERT INTO reward_redemptions (reward_id, user_id, points_spent) VALUES (?, ?, ?)`,
 		rewardID, userID, cost)
@@ -1025,19 +1037,15 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 		}
 	}
 
-	// Debit points for the redemption
-	_, err = tx.ExecContext(ctx,
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
 		 VALUES (?, ?, ?, ?, '')`,
-		userID, -cost, model.ReasonRewardRedeem, redemptionID)
-	if err != nil {
+		userID, -cost, model.ReasonRewardRedeem, redemptionID); err != nil {
 		return nil, err
 	}
 
-	// Decrement stock if limited
 	if stock.Valid {
-		_, err = tx.ExecContext(ctx, `UPDATE rewards SET stock = stock - 1 WHERE id = ?`, rewardID)
-		if err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE rewards SET stock = stock - 1 WHERE id = ?`, rewardID); err != nil {
 			return nil, err
 		}
 	}
@@ -1054,13 +1062,160 @@ func (s *Store) RedeemReward(ctx context.Context, userID, rewardID int64) (*mode
 	}, nil
 }
 
+// redeemSharedPoolTx settles a fully-funded shared pool: every active
+// contributor is debited their saved amount, the pool is marked redeemed,
+// stock decrements once. The caller must be a contributor with a non-zero
+// saved share. Returns the calling user's RewardRedemption row.
+func (s *Store) redeemSharedPoolTx(ctx context.Context, tx *sql.Tx, userID, rewardID int64, stock sql.NullInt64) (*model.RewardRedemption, error) {
+	// Find the active pool for this reward.
+	var poolID int64
+	var poolTarget int
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, target_cost FROM shared_commitment_pools
+		 WHERE reward_id = ? AND status = ?`,
+		rewardID, model.CommitmentActive).Scan(&poolID, &poolTarget)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("no active family goal for this reward — join one first")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// The caller must be a contributor.
+	var callerCommitmentID int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT id FROM reward_commitments
+		 WHERE user_id = ? AND shared_pool_id = ? AND status = ?`,
+		userID, poolID, model.CommitmentActive).Scan(&callerCommitmentID); err == sql.ErrNoRows {
+		return nil, fmt.Errorf("you haven't joined this family goal")
+	} else if err != nil {
+		return nil, err
+	}
+
+	// Pool must be fully funded.
+	var poolSaved int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(-SUM(pt.amount), 0)
+		 FROM point_transactions pt
+		 JOIN reward_commitments rc ON rc.id = pt.reference_id
+		 WHERE rc.shared_pool_id = ? AND rc.status = ?
+		   AND pt.reason IN (?, ?)`,
+		poolID, model.CommitmentActive, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&poolSaved); err != nil {
+		return nil, err
+	}
+	if poolSaved < poolTarget {
+		return nil, fmt.Errorf("family goal not fully funded yet (have %d, need %d)", poolSaved, poolTarget)
+	}
+
+	// For each active contributor: emit goal_break + reward_redeem +
+	// reward_redemption row sized to that contributor's saved share. Caller's
+	// row is returned to the API layer.
+	contributorRows, err := tx.QueryContext(ctx,
+		`SELECT rc.id, rc.user_id, COALESCE(-SUM(pt.amount), 0) AS saved
+		 FROM reward_commitments rc
+		 LEFT JOIN point_transactions pt
+		   ON pt.reference_id = rc.id AND pt.reason IN (?, ?)
+		 WHERE rc.shared_pool_id = ? AND rc.status = ?
+		 GROUP BY rc.id, rc.user_id`,
+		model.ReasonCommitToGoal, model.ReasonGoalBreak, poolID, model.CommitmentActive)
+	if err != nil {
+		return nil, err
+	}
+	type contrib struct {
+		commitmentID int64
+		userID       int64
+		saved        int
+	}
+	var contribs []contrib
+	for contributorRows.Next() {
+		var c contrib
+		if err := contributorRows.Scan(&c.commitmentID, &c.userID, &c.saved); err != nil {
+			contributorRows.Close()
+			return nil, err
+		}
+		contribs = append(contribs, c)
+	}
+	contributorRows.Close()
+
+	var callerRedemption *model.RewardRedemption
+	for _, c := range contribs {
+		if c.saved <= 0 {
+			// A contributor with 0 saved (joined but never funded). Mark them
+			// redeemed but skip the ledger churn.
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE reward_commitments SET status = ?, redeemed_at = CURRENT_TIMESTAMP WHERE id = ?`,
+				model.CommitmentRedeemed, c.commitmentID); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO reward_redemptions (reward_id, user_id, points_spent) VALUES (?, ?, ?)`,
+			rewardID, c.userID, c.saved)
+		if err != nil {
+			return nil, err
+		}
+		redemptionID, _ := res.LastInsertId()
+
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, 'redeemed via family goal')`,
+			c.userID, c.saved, model.ReasonGoalBreak, c.commitmentID); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, '')`,
+			c.userID, -c.saved, model.ReasonRewardRedeem, redemptionID); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE reward_commitments SET status = ?, redeemed_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			model.CommitmentRedeemed, c.commitmentID); err != nil {
+			return nil, err
+		}
+
+		if c.userID == userID {
+			callerRedemption = &model.RewardRedemption{
+				ID:          redemptionID,
+				RewardID:    rewardID,
+				UserID:      userID,
+				PointsSpent: c.saved,
+			}
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE shared_commitment_pools SET status = ?, redeemed_at = CURRENT_TIMESTAMP, redeemed_by_user_id = ? WHERE id = ?`,
+		model.CommitmentRedeemed, userID, poolID); err != nil {
+		return nil, err
+	}
+
+	if stock.Valid {
+		if _, err := tx.ExecContext(ctx, `UPDATE rewards SET stock = stock - 1 WHERE id = ?`, rewardID); err != nil {
+			return nil, err
+		}
+	}
+
+	if callerRedemption == nil {
+		// Caller had 0 saved — surface a synthetic record so the response
+		// shape is consistent. The caller is recorded as the redeemer of the
+		// pool itself via shared_commitment_pools.redeemed_by_user_id.
+		callerRedemption = &model.RewardRedemption{
+			RewardID:    rewardID,
+			UserID:      userID,
+			PointsSpent: 0,
+		}
+	}
+	return callerRedemption, nil
+}
+
 // --- Reward Commitments ---
 
 // ErrActiveCommitmentExists indicates the user already has an active commitment.
 var ErrActiveCommitmentExists = fmt.Errorf("user already has an active commitment")
 
-// scanCommitment fills a RewardCommitment from a row scan and computes the
-// derived AmountSaved from the ledger.
+// hydrateCommitmentSaved derives AmountSaved for a commitment from the ledger.
 func (s *Store) hydrateCommitmentSaved(ctx context.Context, q interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }, c *model.RewardCommitment) error {
@@ -1070,8 +1225,9 @@ func (s *Store) hydrateCommitmentSaved(ctx context.Context, q interface {
 		c.ID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&c.AmountSaved)
 }
 
-// GetActiveCommitmentForUser returns the user's active commitment with reward
-// metadata and a derived AmountSaved, or nil if there isn't one.
+// GetActiveCommitmentForUser returns the user's active personal commitment
+// (shared shares are excluded — see ListActiveCommitmentsForUser for the
+// full picture).
 func (s *Store) GetActiveCommitmentForUser(ctx context.Context, userID int64) (*model.RewardCommitment, error) {
 	c := &model.RewardCommitment{}
 	var redeemedAt, cancelledAt sql.NullTime
@@ -1081,7 +1237,7 @@ func (s *Store) GetActiveCommitmentForUser(ctx context.Context, userID int64) (*
 		        rc.redeemed_at, rc.cancelled_at
 		 FROM reward_commitments rc
 		 JOIN rewards r ON r.id = rc.reward_id
-		 WHERE rc.user_id = ? AND rc.status = ?`,
+		 WHERE rc.user_id = ? AND rc.status = ? AND rc.shared_pool_id IS NULL`,
 		userID, model.CommitmentActive).
 		Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon, &c.TargetCost,
 			&c.AutoContributePercent, &c.Status, &c.CreatedAt, &redeemedAt, &cancelledAt)
@@ -1103,13 +1259,123 @@ func (s *Store) GetActiveCommitmentForUser(ctx context.Context, userID int64) (*
 	return c, nil
 }
 
+// ListActiveCommitmentsForUser returns all active commitments — both the
+// kid's personal goal (if any) and every shared family pool they've joined.
+// Shared rows have Pool populated for UI rendering.
+func (s *Store) ListActiveCommitmentsForUser(ctx context.Context, userID int64) ([]model.RewardCommitment, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT rc.id, rc.user_id, rc.reward_id, r.name, r.icon, rc.target_cost,
+		        rc.auto_contribute_percent, rc.status, rc.created_at,
+		        rc.redeemed_at, rc.cancelled_at, rc.shared_pool_id
+		 FROM reward_commitments rc
+		 JOIN rewards r ON r.id = rc.reward_id
+		 WHERE rc.user_id = ? AND rc.status = ?
+		 ORDER BY rc.shared_pool_id IS NULL DESC, rc.created_at DESC`,
+		userID, model.CommitmentActive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []model.RewardCommitment
+	for rows.Next() {
+		var c model.RewardCommitment
+		var redeemedAt, cancelledAt sql.NullTime
+		var poolID sql.NullInt64
+		if err := rows.Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon,
+			&c.TargetCost, &c.AutoContributePercent, &c.Status, &c.CreatedAt,
+			&redeemedAt, &cancelledAt, &poolID); err != nil {
+			return nil, err
+		}
+		if redeemedAt.Valid {
+			c.RedeemedAt = &redeemedAt.Time
+		}
+		if cancelledAt.Valid {
+			c.CancelledAt = &cancelledAt.Time
+		}
+		if poolID.Valid {
+			id := poolID.Int64
+			c.SharedPoolID = &id
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range out {
+		if err := s.hydrateCommitmentSaved(ctx, s.db, &out[i]); err != nil {
+			return nil, err
+		}
+		if out[i].SharedPoolID != nil {
+			pool, err := s.GetSharedPool(ctx, *out[i].SharedPoolID)
+			if err != nil {
+				return nil, err
+			}
+			out[i].Pool = pool
+		}
+	}
+	return out, nil
+}
+
+// GetSharedPool returns a shared commitment pool with derived AmountSaved
+// (sum across active contributors) and the contributor leaderboard.
+func (s *Store) GetSharedPool(ctx context.Context, poolID int64) (*model.SharedCommitmentPool, error) {
+	p := &model.SharedCommitmentPool{}
+	var redeemedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx,
+		`SELECT scp.id, scp.reward_id, r.name, r.icon, scp.target_cost, scp.status,
+		        scp.created_at, scp.redeemed_at
+		 FROM shared_commitment_pools scp
+		 JOIN rewards r ON r.id = scp.reward_id
+		 WHERE scp.id = ?`, poolID).
+		Scan(&p.ID, &p.RewardID, &p.RewardName, &p.RewardIcon, &p.TargetCost, &p.Status,
+			&p.CreatedAt, &redeemedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if redeemedAt.Valid {
+		p.RedeemedAt = &redeemedAt.Time
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT u.id, u.name, u.avatar_url, COALESCE(-SUM(pt.amount), 0) AS saved
+		 FROM reward_commitments rc
+		 JOIN users u ON u.id = rc.user_id
+		 LEFT JOIN point_transactions pt
+		   ON pt.reference_id = rc.id AND pt.reason IN (?, ?)
+		 WHERE rc.shared_pool_id = ? AND rc.status = ?
+		 GROUP BY u.id, u.name, u.avatar_url
+		 ORDER BY saved DESC, u.name ASC`,
+		model.ReasonCommitToGoal, model.ReasonGoalBreak, poolID, model.CommitmentActive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var total int
+	for rows.Next() {
+		var c model.PoolContributor
+		if err := rows.Scan(&c.UserID, &c.UserName, &c.AvatarURL, &c.AmountSaved); err != nil {
+			return nil, err
+		}
+		total += c.AmountSaved
+		p.Contributors = append(p.Contributors, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	p.AmountSaved = total
+	return p, nil
+}
+
 // ListCommitmentsForUser returns the user's commitments (active + history),
 // most recent first.
 func (s *Store) ListCommitmentsForUser(ctx context.Context, userID int64) ([]model.RewardCommitment, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT rc.id, rc.user_id, rc.reward_id, r.name, r.icon, rc.target_cost,
 		        rc.auto_contribute_percent, rc.status, rc.created_at,
-		        rc.redeemed_at, rc.cancelled_at
+		        rc.redeemed_at, rc.cancelled_at, rc.shared_pool_id
 		 FROM reward_commitments rc
 		 JOIN rewards r ON r.id = rc.reward_id
 		 WHERE rc.user_id = ?
@@ -1122,9 +1388,10 @@ func (s *Store) ListCommitmentsForUser(ctx context.Context, userID int64) ([]mod
 	for rows.Next() {
 		var c model.RewardCommitment
 		var redeemedAt, cancelledAt sql.NullTime
+		var poolID sql.NullInt64
 		if err := rows.Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon,
 			&c.TargetCost, &c.AutoContributePercent, &c.Status, &c.CreatedAt,
-			&redeemedAt, &cancelledAt); err != nil {
+			&redeemedAt, &cancelledAt, &poolID); err != nil {
 			return nil, err
 		}
 		if redeemedAt.Valid {
@@ -1132,6 +1399,10 @@ func (s *Store) ListCommitmentsForUser(ctx context.Context, userID int64) ([]mod
 		}
 		if cancelledAt.Valid {
 			c.CancelledAt = &cancelledAt.Time
+		}
+		if poolID.Valid {
+			id := poolID.Int64
+			c.SharedPoolID = &id
 		}
 		out = append(out, c)
 	}
@@ -1146,10 +1417,12 @@ func (s *Store) ListCommitmentsForUser(ctx context.Context, userID int64) ([]mod
 	return out, nil
 }
 
-// CreateCommitment opens a new active commitment for the user, snapshotting
-// the reward's effective cost as the target. The kid keeps that price even if
-// admins later raise the reward's cost. Returns ErrActiveCommitmentExists if
-// the user already has an active commitment.
+// CreateCommitment opens a new active commitment for the user. For personal
+// (non-shareable) rewards it snapshots the per-user effective cost as the
+// target and refuses if the kid already has a personal goal. For shareable
+// rewards it creates the shared pool on demand (snapshotting the base cost
+// once for everyone) and joins the kid in — with no impact on their personal
+// goal slot.
 func (s *Store) CreateCommitment(ctx context.Context, userID, rewardID int64, autoPercent int) (*model.RewardCommitment, error) {
 	if autoPercent < 0 || autoPercent > 100 {
 		return nil, fmt.Errorf("auto_contribute_percent must be between 0 and 100")
@@ -1161,28 +1434,19 @@ func (s *Store) CreateCommitment(ctx context.Context, userID, rewardID int64, au
 	}
 	defer tx.Rollback()
 
-	// Refuse if user has an active commitment.
-	var existing int64
-	if err := tx.QueryRowContext(ctx,
-		`SELECT id FROM reward_commitments WHERE user_id = ? AND status = ?`,
-		userID, model.CommitmentActive).Scan(&existing); err == nil {
-		return nil, ErrActiveCommitmentExists
-	} else if err != sql.ErrNoRows {
-		return nil, err
-	}
-
-	// Snapshot the cost the kid sees (per-user override or base cost).
 	var baseCost int
-	var active int
+	var active, shareable int
 	if err := tx.QueryRowContext(ctx,
-		`SELECT cost, active FROM rewards WHERE id = ?`, rewardID).Scan(&baseCost, &active); err != nil {
+		`SELECT cost, active, shareable FROM rewards WHERE id = ?`, rewardID).
+		Scan(&baseCost, &active, &shareable); err != nil {
 		return nil, fmt.Errorf("reward not found")
 	}
 	if active != 1 {
 		return nil, fmt.Errorf("reward is not active")
 	}
 
-	// Honour assignments + per-user pricing.
+	// Honour assignments — applies to both shareable and personal rewards so
+	// admins can scope a family goal to a subset of kids if they want.
 	var hasAssignments bool
 	if err := tx.QueryRowContext(ctx,
 		`SELECT EXISTS(SELECT 1 FROM reward_assignments WHERE reward_id = ?)`, rewardID).
@@ -1200,32 +1464,139 @@ func (s *Store) CreateCommitment(ctx context.Context, userID, rewardID int64, au
 			return nil, fmt.Errorf("reward is not available to you")
 		}
 	}
-	target := baseCost
-	var customCost sql.NullInt64
-	tx.QueryRowContext(ctx,
-		`SELECT custom_cost FROM reward_assignments WHERE reward_id = ? AND user_id = ?`,
-		rewardID, userID).Scan(&customCost)
-	if customCost.Valid {
-		target = int(customCost.Int64)
-	}
 
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO reward_commitments (user_id, reward_id, target_cost, auto_contribute_percent)
-		 VALUES (?, ?, ?, ?)`,
-		userID, rewardID, target, autoPercent); err != nil {
-		return nil, err
+	var commitmentID int64
+
+	if shareable == 1 {
+		// Find or create the active shared pool for this reward.
+		var poolID int64
+		var poolTarget int
+		err := tx.QueryRowContext(ctx,
+			`SELECT id, target_cost FROM shared_commitment_pools
+			 WHERE reward_id = ? AND status = ?`,
+			rewardID, model.CommitmentActive).Scan(&poolID, &poolTarget)
+		if err == sql.ErrNoRows {
+			// First contributor opens the pool. Snapshot the base cost so
+			// admins changing the price mid-pool can't punish the savers.
+			// Per-user pricing (custom_cost) is intentionally NOT applied to
+			// shared pools — one cost for the shared goal.
+			res, err := tx.ExecContext(ctx,
+				`INSERT INTO shared_commitment_pools (reward_id, target_cost) VALUES (?, ?)`,
+				rewardID, baseCost)
+			if err != nil {
+				return nil, err
+			}
+			poolID, _ = res.LastInsertId()
+			poolTarget = baseCost
+		} else if err != nil {
+			return nil, err
+		}
+
+		// Block double-join (and the partial unique index would too).
+		var existing int64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT id FROM reward_commitments
+			 WHERE user_id = ? AND shared_pool_id = ? AND status = ?`,
+			userID, poolID, model.CommitmentActive).Scan(&existing); err == nil {
+			return nil, fmt.Errorf("you've already joined this family goal")
+		} else if err != sql.ErrNoRows {
+			return nil, err
+		}
+
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO reward_commitments (user_id, reward_id, target_cost, auto_contribute_percent, shared_pool_id)
+			 VALUES (?, ?, ?, ?, ?)`,
+			userID, rewardID, poolTarget, autoPercent, poolID)
+		if err != nil {
+			return nil, err
+		}
+		commitmentID, _ = res.LastInsertId()
+	} else {
+		// Personal: refuse if user has an active personal commitment.
+		var existing int64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT id FROM reward_commitments
+			 WHERE user_id = ? AND status = ? AND shared_pool_id IS NULL`,
+			userID, model.CommitmentActive).Scan(&existing); err == nil {
+			return nil, ErrActiveCommitmentExists
+		} else if err != sql.ErrNoRows {
+			return nil, err
+		}
+
+		target := baseCost
+		var customCost sql.NullInt64
+		tx.QueryRowContext(ctx,
+			`SELECT custom_cost FROM reward_assignments WHERE reward_id = ? AND user_id = ?`,
+			rewardID, userID).Scan(&customCost)
+		if customCost.Valid {
+			target = int(customCost.Int64)
+		}
+
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO reward_commitments (user_id, reward_id, target_cost, auto_contribute_percent)
+			 VALUES (?, ?, ?, ?)`,
+			userID, rewardID, target, autoPercent)
+		if err != nil {
+			return nil, err
+		}
+		commitmentID, _ = res.LastInsertId()
 	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return s.GetActiveCommitmentForUser(ctx, userID)
+	return s.GetCommitment(ctx, commitmentID)
+}
+
+// GetCommitment loads a single commitment by id, with reward metadata and
+// derived AmountSaved (and Pool, for shared shares).
+func (s *Store) GetCommitment(ctx context.Context, commitmentID int64) (*model.RewardCommitment, error) {
+	c := &model.RewardCommitment{}
+	var redeemedAt, cancelledAt sql.NullTime
+	var poolID sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT rc.id, rc.user_id, rc.reward_id, r.name, r.icon, rc.target_cost,
+		        rc.auto_contribute_percent, rc.status, rc.created_at,
+		        rc.redeemed_at, rc.cancelled_at, rc.shared_pool_id
+		 FROM reward_commitments rc
+		 JOIN rewards r ON r.id = rc.reward_id
+		 WHERE rc.id = ?`, commitmentID).
+		Scan(&c.ID, &c.UserID, &c.RewardID, &c.RewardName, &c.RewardIcon, &c.TargetCost,
+			&c.AutoContributePercent, &c.Status, &c.CreatedAt, &redeemedAt, &cancelledAt, &poolID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if redeemedAt.Valid {
+		c.RedeemedAt = &redeemedAt.Time
+	}
+	if cancelledAt.Valid {
+		c.CancelledAt = &cancelledAt.Time
+	}
+	if poolID.Valid {
+		id := poolID.Int64
+		c.SharedPoolID = &id
+	}
+	if err := s.hydrateCommitmentSaved(ctx, s.db, c); err != nil {
+		return nil, err
+	}
+	if c.SharedPoolID != nil {
+		pool, err := s.GetSharedPool(ctx, *c.SharedPoolID)
+		if err != nil {
+			return nil, err
+		}
+		c.Pool = pool
+	}
+	return c, nil
 }
 
 // ContributeToCommitment moves `amount` points from the user's spendable
-// balance into their active commitment. The amount is capped at the
-// commitment's remaining target so kids can't over-fund. Returns an error if
-// spendable balance is insufficient.
+// balance into their active commitment. The amount is capped so kids can't
+// over-fund: for personal goals it caps at the row's remaining target, for
+// shared shares it caps at the pool's remaining target (so the last kid in
+// can't push the pool past 100%).
 func (s *Store) ContributeToCommitment(ctx context.Context, userID, commitmentID int64, amount int) error {
 	if amount <= 0 {
 		return fmt.Errorf("amount must be positive")
@@ -1239,9 +1610,10 @@ func (s *Store) ContributeToCommitment(ctx context.Context, userID, commitmentID
 	var ownerID int64
 	var status string
 	var target int
+	var poolID sql.NullInt64
 	if err := tx.QueryRowContext(ctx,
-		`SELECT user_id, status, target_cost FROM reward_commitments WHERE id = ?`,
-		commitmentID).Scan(&ownerID, &status, &target); err != nil {
+		`SELECT user_id, status, target_cost, shared_pool_id FROM reward_commitments WHERE id = ?`,
+		commitmentID).Scan(&ownerID, &status, &target, &poolID); err != nil {
 		return fmt.Errorf("commitment not found")
 	}
 	if ownerID != userID {
@@ -1251,16 +1623,36 @@ func (s *Store) ContributeToCommitment(ctx context.Context, userID, commitmentID
 		return fmt.Errorf("commitment is not active")
 	}
 
-	var saved int
-	if err := tx.QueryRowContext(ctx,
-		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
-		 WHERE reference_id = ? AND reason IN (?, ?)`,
-		commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
-		return err
+	var remaining int
+	if poolID.Valid {
+		var poolTarget, poolSaved int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT target_cost FROM shared_commitment_pools WHERE id = ?`, poolID.Int64).
+			Scan(&poolTarget); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COALESCE(-SUM(pt.amount), 0)
+			 FROM point_transactions pt
+			 JOIN reward_commitments rc ON rc.id = pt.reference_id
+			 WHERE rc.shared_pool_id = ? AND rc.status = ? AND pt.reason IN (?, ?)`,
+			poolID.Int64, model.CommitmentActive, model.ReasonCommitToGoal, model.ReasonGoalBreak).
+			Scan(&poolSaved); err != nil {
+			return err
+		}
+		remaining = poolTarget - poolSaved
+	} else {
+		var saved int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+			 WHERE reference_id = ? AND reason IN (?, ?)`,
+			commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+			return err
+		}
+		remaining = target - saved
 	}
-	remaining := target - saved
 	if remaining <= 0 {
-		return fmt.Errorf("commitment is already fully funded")
+		return fmt.Errorf("goal is already fully funded")
 	}
 	if amount > remaining {
 		amount = remaining
@@ -1353,56 +1745,100 @@ func (s *Store) BreakCommitment(ctx context.Context, userID, commitmentID int64)
 	return tx.Commit()
 }
 
-// applyAutoContributeTx auto-routes a fraction of a chore credit into the
-// user's active commitment, capped at the commitment's remaining target. A
-// no-op when there's no active commitment, percent is zero, or the
-// commitment is already fully funded.
+// applyAutoContributeTx auto-routes a fraction of a chore credit into each
+// of the user's active commitments (personal first, then shared shares in
+// join order). Each commitment is capped at its remaining target — for
+// shared shares the cap is the *pool's* remaining capacity so the last kid
+// in can't push the pool past 100%. Stops when the credit is exhausted.
 func (s *Store) applyAutoContributeTx(ctx context.Context, tx *sql.Tx, userID, completionID int64, creditAmount int) error {
 	if creditAmount <= 0 {
 		return nil
 	}
-	var commitmentID int64
-	var pct int
-	var target int
-	err := tx.QueryRowContext(ctx,
-		`SELECT id, auto_contribute_percent, target_cost FROM reward_commitments
-		 WHERE user_id = ? AND status = ?`,
-		userID, model.CommitmentActive).Scan(&commitmentID, &pct, &target)
-	if err == sql.ErrNoRows {
-		return nil
-	}
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, auto_contribute_percent, target_cost, shared_pool_id
+		 FROM reward_commitments
+		 WHERE user_id = ? AND status = ?
+		 ORDER BY shared_pool_id IS NULL DESC, created_at ASC`,
+		userID, model.CommitmentActive)
 	if err != nil {
 		return err
 	}
-	if pct <= 0 {
-		return nil
+	type slot struct {
+		id     int64
+		pct    int
+		target int
+		poolID sql.NullInt64
 	}
-
-	var saved int
-	if err := tx.QueryRowContext(ctx,
-		`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
-		 WHERE reference_id = ? AND reason IN (?, ?)`,
-		commitmentID, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+	var slots []slot
+	for rows.Next() {
+		var s slot
+		if err := rows.Scan(&s.id, &s.pct, &s.target, &s.poolID); err != nil {
+			rows.Close()
+			return err
+		}
+		slots = append(slots, s)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
 		return err
 	}
-	remaining := target - saved
-	if remaining <= 0 {
-		return nil
-	}
-	contribution := creditAmount * pct / 100
-	if contribution <= 0 {
-		return nil
-	}
-	if contribution > remaining {
-		contribution = remaining
-	}
 
+	creditLeft := creditAmount
 	note := fmt.Sprintf("auto:completion:%d", completionID)
-	_, err = tx.ExecContext(ctx,
-		`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
-		 VALUES (?, ?, ?, ?, ?)`,
-		userID, -contribution, model.ReasonCommitToGoal, commitmentID, note)
-	return err
+	for _, sl := range slots {
+		if sl.pct <= 0 || creditLeft <= 0 {
+			continue
+		}
+		var remaining int
+		if sl.poolID.Valid {
+			var poolTarget, poolSaved int
+			if err := tx.QueryRowContext(ctx,
+				`SELECT target_cost FROM shared_commitment_pools WHERE id = ?`, sl.poolID.Int64).
+				Scan(&poolTarget); err != nil {
+				return err
+			}
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COALESCE(-SUM(pt.amount), 0)
+				 FROM point_transactions pt
+				 JOIN reward_commitments rc ON rc.id = pt.reference_id
+				 WHERE rc.shared_pool_id = ? AND rc.status = ? AND pt.reason IN (?, ?)`,
+				sl.poolID.Int64, model.CommitmentActive, model.ReasonCommitToGoal, model.ReasonGoalBreak).
+				Scan(&poolSaved); err != nil {
+				return err
+			}
+			remaining = poolTarget - poolSaved
+		} else {
+			var saved int
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COALESCE(-SUM(amount), 0) FROM point_transactions
+				 WHERE reference_id = ? AND reason IN (?, ?)`,
+				sl.id, model.ReasonCommitToGoal, model.ReasonGoalBreak).Scan(&saved); err != nil {
+				return err
+			}
+			remaining = sl.target - saved
+		}
+		if remaining <= 0 {
+			continue
+		}
+		contribution := creditAmount * sl.pct / 100
+		if contribution <= 0 {
+			continue
+		}
+		if contribution > remaining {
+			contribution = remaining
+		}
+		if contribution > creditLeft {
+			contribution = creditLeft
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, ?)`,
+			userID, -contribution, model.ReasonCommitToGoal, sl.id, note); err != nil {
+			return err
+		}
+		creditLeft -= contribution
+	}
+	return nil
 }
 
 // reverseAutoContributeTx reverses any auto-contributions tied to this
@@ -1660,15 +2096,46 @@ func (s *Store) UndoRedemption(ctx context.Context, redemptionID int64) error {
 	// goal_break we emitted at redeem time and reactivate the commitment so
 	// the saved points sit in the goal again. We identify the commitment by
 	// the surviving commit_to_goal rows for (this user, this reward).
+	//
+	// Shared pools are intentionally restricted to per-kid refund only: the
+	// pool stays redeemed (other contributors have their own redemptions and
+	// the reward is presumed delivered), and the kid's commitment row goes
+	// back to a quasi-cancelled state. This keeps the half-state from
+	// getting weirder than it needs to.
 	var commitmentID int64
+	var commitmentPoolID sql.NullInt64
 	err = tx.QueryRowContext(ctx,
-		`SELECT id FROM reward_commitments
+		`SELECT id, shared_pool_id FROM reward_commitments
 		 WHERE user_id = ? AND reward_id = ? AND status = ?`,
-		userID, rewardID, model.CommitmentRedeemed).Scan(&commitmentID)
+		userID, rewardID, model.CommitmentRedeemed).Scan(&commitmentID, &commitmentPoolID)
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
-	if commitmentID != 0 {
+	if commitmentID != 0 && commitmentPoolID.Valid {
+		// Shared share: drop the redemption-time goal_break (note='redeemed
+		// via family goal') so net spendable change for this kid is +pointsSpent
+		// and mark the commitment cancelled so it doesn't show as active.
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM point_transactions
+			 WHERE reason = ? AND reference_id = ? AND note = 'redeemed via family goal'`,
+			model.ReasonGoalBreak, commitmentID); err != nil {
+			return err
+		}
+		// Refund the kid's spent share to spendable.
+		if pointsSpent > 0 {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+				 VALUES (?, ?, ?, ?, 'undo shared redemption refund')`,
+				userID, pointsSpent, model.ReasonGoalBreak, commitmentID); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE reward_commitments SET status = ?, redeemed_at = NULL, cancelled_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			model.CommitmentCancelled, commitmentID); err != nil {
+			return err
+		}
+	} else if commitmentID != 0 {
 		// Drop the redemption-time goal_break so the saved points sit in the
 		// commitment again, and try to flip the commitment back to active.
 		// If the kid started a new active commitment in the meantime we can't
@@ -1680,9 +2147,12 @@ func (s *Store) UndoRedemption(ctx context.Context, redemptionID int64) error {
 			model.ReasonGoalBreak, commitmentID); err != nil {
 			return err
 		}
+		// Only personal-active conflicts here — shared shares don't compete
+		// for the personal slot, so multiple actives can coexist.
 		var otherActive int
 		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(1) FROM reward_commitments WHERE user_id = ? AND status = ? AND id != ?`,
+			`SELECT COUNT(1) FROM reward_commitments
+			 WHERE user_id = ? AND status = ? AND shared_pool_id IS NULL AND id != ?`,
 			userID, model.CommitmentActive, commitmentID).Scan(&otherActive); err != nil {
 			return err
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2705,3 +2705,261 @@ func TestCommitmentSnapshotsTargetCost(t *testing.T) {
 		t.Errorf("expected target_cost still 100 (snapshotted), got %d", got.TargetCost)
 	}
 }
+
+// ===== Shared / Family Goals =====
+
+func TestSharedPoolJoinAndContribute(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	alice := createTestUser(t, s, "Alice", "child")
+	bob := createTestUser(t, s, "Bob", "child")
+
+	reward := &model.Reward{Name: "Minecraft", Cost: 600, Active: true, Shareable: true, CreatedBy: parent.ID}
+	if err := s.CreateReward(ctx, reward); err != nil {
+		t.Fatalf("CreateReward: %v", err)
+	}
+	s.AdminAdjustPoints(ctx, alice.ID, 500, "seed")
+	s.AdminAdjustPoints(ctx, bob.ID, 300, "seed")
+
+	// Alice joins first — creates the pool.
+	a, err := s.CreateCommitment(ctx, alice.ID, reward.ID, 0)
+	if err != nil {
+		t.Fatalf("Alice CreateCommitment: %v", err)
+	}
+	if a.SharedPoolID == nil {
+		t.Fatalf("expected SharedPoolID populated for shareable reward")
+	}
+	if a.Pool == nil || a.Pool.TargetCost != 600 {
+		t.Fatalf("expected pool target=600, got %+v", a.Pool)
+	}
+
+	// Bob joins same pool — should reuse not create a new one.
+	b, err := s.CreateCommitment(ctx, bob.ID, reward.ID, 0)
+	if err != nil {
+		t.Fatalf("Bob CreateCommitment: %v", err)
+	}
+	if b.SharedPoolID == nil || *a.SharedPoolID != *b.SharedPoolID {
+		t.Errorf("expected Bob to join same pool as Alice (alice=%v bob=%v)", a.SharedPoolID, b.SharedPoolID)
+	}
+
+	// Each kid contributes their share. Pool total should sum across kids.
+	if err := s.ContributeToCommitment(ctx, alice.ID, a.ID, 400); err != nil {
+		t.Fatalf("Alice contribute: %v", err)
+	}
+	if err := s.ContributeToCommitment(ctx, bob.ID, b.ID, 200); err != nil {
+		t.Fatalf("Bob contribute: %v", err)
+	}
+
+	pool, _ := s.GetSharedPool(ctx, *a.SharedPoolID)
+	if pool.AmountSaved != 600 {
+		t.Errorf("expected pool saved=600, got %d", pool.AmountSaved)
+	}
+	if len(pool.Contributors) != 2 {
+		t.Errorf("expected 2 contributors, got %d", len(pool.Contributors))
+	}
+
+	// Personal commitment should be unaffected by shared participation.
+	if existing, _ := s.GetActiveCommitmentForUser(ctx, alice.ID); existing != nil {
+		t.Errorf("expected no active personal commitment for alice, got %+v", existing)
+	}
+	// Alice should still be able to start a personal goal.
+	cheap := &model.Reward{Name: "LEGO", Cost: 50, Active: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, cheap)
+	if _, err := s.CreateCommitment(ctx, alice.ID, cheap.ID, 0); err != nil {
+		t.Errorf("expected personal commitment alongside shared share, got error: %v", err)
+	}
+}
+
+func TestSharedPoolContributeCapsAtPoolRemaining(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	alice := createTestUser(t, s, "Alice", "child")
+	bob := createTestUser(t, s, "Bob", "child")
+
+	reward := &model.Reward{Name: "Family Trip", Cost: 100, Active: true, Shareable: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	s.AdminAdjustPoints(ctx, alice.ID, 200, "seed")
+	s.AdminAdjustPoints(ctx, bob.ID, 200, "seed")
+
+	a, _ := s.CreateCommitment(ctx, alice.ID, reward.ID, 0)
+	b, _ := s.CreateCommitment(ctx, bob.ID, reward.ID, 0)
+
+	// Alice fills 90 of the pool first.
+	if err := s.ContributeToCommitment(ctx, alice.ID, a.ID, 90); err != nil {
+		t.Fatalf("Alice contribute: %v", err)
+	}
+	// Bob asks for 50 — should be capped at 10 (pool has 10 left).
+	if err := s.ContributeToCommitment(ctx, bob.ID, b.ID, 50); err != nil {
+		t.Fatalf("Bob contribute: %v", err)
+	}
+	pool, _ := s.GetSharedPool(ctx, *a.SharedPoolID)
+	if pool.AmountSaved != 100 {
+		t.Errorf("expected pool capped at 100, got %d", pool.AmountSaved)
+	}
+	bobBal, _ := s.GetPointBalance(ctx, bob.ID)
+	if bobBal != 190 {
+		t.Errorf("expected bob spendable 190 (only 10 contributed), got %d", bobBal)
+	}
+}
+
+func TestSharedPoolRedemptionDebitsEachContributor(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	alice := createTestUser(t, s, "Alice", "child")
+	bob := createTestUser(t, s, "Bob", "child")
+
+	reward := &model.Reward{Name: "Minecraft", Cost: 300, Active: true, Shareable: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	s.AdminAdjustPoints(ctx, alice.ID, 250, "seed")
+	s.AdminAdjustPoints(ctx, bob.ID, 250, "seed")
+
+	a, _ := s.CreateCommitment(ctx, alice.ID, reward.ID, 0)
+	b, _ := s.CreateCommitment(ctx, bob.ID, reward.ID, 0)
+	s.ContributeToCommitment(ctx, alice.ID, a.ID, 200)
+	s.ContributeToCommitment(ctx, bob.ID, b.ID, 100)
+
+	// Bob hits redeem (any contributor can).
+	if _, err := s.RedeemReward(ctx, bob.ID, reward.ID); err != nil {
+		t.Fatalf("RedeemReward: %v", err)
+	}
+
+	// Each kid loses exactly their contribution from total balance, spendable
+	// unchanged net (saved → spent in one tx).
+	if bal, _ := s.GetPointBalance(ctx, alice.ID); bal != 50 {
+		t.Errorf("expected alice spendable 50 (250 seed - 200 contributed), got %d", bal)
+	}
+	if bal, _ := s.GetPointBalance(ctx, bob.ID); bal != 150 {
+		t.Errorf("expected bob spendable 150 (250 seed - 100 contributed), got %d", bal)
+	}
+
+	pool, _ := s.GetSharedPool(ctx, *a.SharedPoolID)
+	if pool.Status != model.CommitmentRedeemed {
+		t.Errorf("expected pool redeemed, got %s", pool.Status)
+	}
+
+	// Both kids should have a redemption history entry sized to their share.
+	aliceHist, _ := s.ListRedemptionsForUser(ctx, alice.ID, 10)
+	if len(aliceHist) != 1 || aliceHist[0].PointsSpent != 200 {
+		t.Errorf("expected alice redemption=200, got %+v", aliceHist)
+	}
+	bobHist, _ := s.ListRedemptionsForUser(ctx, bob.ID, 10)
+	if len(bobHist) != 1 || bobHist[0].PointsSpent != 100 {
+		t.Errorf("expected bob redemption=100, got %+v", bobHist)
+	}
+}
+
+func TestSharedPoolRedeemFailsWhenNotFunded(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	alice := createTestUser(t, s, "Alice", "child")
+	reward := &model.Reward{Name: "Big thing", Cost: 1000, Active: true, Shareable: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	s.AdminAdjustPoints(ctx, alice.ID, 500, "seed")
+
+	a, _ := s.CreateCommitment(ctx, alice.ID, reward.ID, 0)
+	s.ContributeToCommitment(ctx, alice.ID, a.ID, 200)
+
+	if _, err := s.RedeemReward(ctx, alice.ID, reward.ID); err == nil {
+		t.Errorf("expected redemption to fail when pool isn't fully funded")
+	}
+}
+
+func TestSharedPoolBreakRefundsOnlyOwnContribution(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	alice := createTestUser(t, s, "Alice", "child")
+	bob := createTestUser(t, s, "Bob", "child")
+	reward := &model.Reward{Name: "Game", Cost: 200, Active: true, Shareable: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, reward)
+	s.AdminAdjustPoints(ctx, alice.ID, 100, "seed")
+	s.AdminAdjustPoints(ctx, bob.ID, 100, "seed")
+
+	a, _ := s.CreateCommitment(ctx, alice.ID, reward.ID, 0)
+	b, _ := s.CreateCommitment(ctx, bob.ID, reward.ID, 0)
+	s.ContributeToCommitment(ctx, alice.ID, a.ID, 60)
+	s.ContributeToCommitment(ctx, bob.ID, b.ID, 40)
+
+	if err := s.BreakCommitment(ctx, alice.ID, a.ID); err != nil {
+		t.Fatalf("Alice break: %v", err)
+	}
+	if bal, _ := s.GetPointBalance(ctx, alice.ID); bal != 100 {
+		t.Errorf("expected alice refunded to 100, got %d", bal)
+	}
+	if bal, _ := s.GetPointBalance(ctx, bob.ID); bal != 60 {
+		t.Errorf("expected bob still committed 40 (spendable 60), got %d", bal)
+	}
+	// Pool should still be active so Bob (and others) can keep saving.
+	pool, _ := s.GetSharedPool(ctx, *a.SharedPoolID)
+	if pool.Status != model.CommitmentActive {
+		t.Errorf("expected pool to remain active after one kid leaves, got %s", pool.Status)
+	}
+	if pool.AmountSaved != 40 {
+		t.Errorf("expected pool to retain bob's 40, got %d", pool.AmountSaved)
+	}
+}
+
+func TestSharedPoolAutoContributeStacksWithPersonal(t *testing.T) {
+	s := setupStore(t)
+	ctx := context.Background()
+
+	parent := createTestUser(t, s, "Parent", "admin")
+	kid := createTestUser(t, s, "Kid", "child")
+
+	personal := &model.Reward{Name: "LEGO", Cost: 200, Active: true, CreatedBy: parent.ID}
+	family := &model.Reward{Name: "Minecraft", Cost: 600, Active: true, Shareable: true, CreatedBy: parent.ID}
+	s.CreateReward(ctx, personal)
+	s.CreateReward(ctx, family)
+
+	if _, err := s.CreateCommitment(ctx, kid.ID, personal.ID, 50); err != nil {
+		t.Fatalf("personal commitment: %v", err)
+	}
+	if _, err := s.CreateCommitment(ctx, kid.ID, family.ID, 25); err != nil {
+		t.Fatalf("shared commitment: %v", err)
+	}
+
+	chore := createTestChore(t, s, "Big chore", 100, parent.ID)
+	cs := createTestSchedule(t, s, chore.ID, kid.ID, 1)
+	cc := &model.ChoreCompletion{ChoreScheduleID: cs.ID, CompletedBy: kid.ID, Status: model.StatusApproved, CompletionDate: "2026-05-06"}
+	s.CompleteChore(ctx, cc)
+	if err := s.CreditChorePoints(ctx, kid.ID, cc.ID, 100); err != nil {
+		t.Fatalf("CreditChorePoints: %v", err)
+	}
+
+	// Expect 50 to personal, 25 to shared, 25 left spendable.
+	bal, _ := s.GetPointBalance(ctx, kid.ID)
+	if bal != 25 {
+		t.Errorf("expected spendable 25 (100 credit - 50 personal - 25 shared), got %d", bal)
+	}
+
+	commitments, err := s.ListActiveCommitmentsForUser(ctx, kid.ID)
+	if err != nil {
+		t.Fatalf("ListActiveCommitmentsForUser: %v", err)
+	}
+	if len(commitments) != 2 {
+		t.Fatalf("expected 2 active commitments, got %d", len(commitments))
+	}
+	var personalSaved, sharedSaved int
+	for _, c := range commitments {
+		if c.SharedPoolID == nil {
+			personalSaved = c.AmountSaved
+		} else {
+			sharedSaved = c.AmountSaved
+		}
+	}
+	if personalSaved != 50 {
+		t.Errorf("expected personal saved=50, got %d", personalSaved)
+	}
+	if sharedSaved != 25 {
+		t.Errorf("expected shared saved=25, got %d", sharedSaved)
+	}
+}

--- a/migrations/014_shareable_rewards.down.sql
+++ b/migrations/014_shareable_rewards.down.sql
@@ -1,0 +1,25 @@
+-- Drop any active commitment rows tied to a shared pool — the old per-user
+-- partial unique index can't see the shared_pool_id discriminator and a
+-- personal-active row already exists for these users in the typical case.
+-- Cancelled / redeemed shared rows survive (their status keeps them out of
+-- the index predicate).
+UPDATE reward_commitments
+   SET status = 'cancelled', cancelled_at = CURRENT_TIMESTAMP
+ WHERE status = 'active' AND shared_pool_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_reward_commitments_one_active_share_per_pool;
+DROP INDEX IF EXISTS idx_reward_commitments_one_active_personal;
+DROP INDEX IF EXISTS idx_reward_commitments_pool;
+
+-- Restore the original "one active commitment per user" rule.
+CREATE UNIQUE INDEX idx_reward_commitments_one_active
+    ON reward_commitments(user_id)
+    WHERE status = 'active';
+
+ALTER TABLE reward_commitments DROP COLUMN shared_pool_id;
+
+DROP INDEX IF EXISTS idx_shared_pools_status;
+DROP INDEX IF EXISTS idx_shared_pools_one_active_per_reward;
+DROP TABLE IF EXISTS shared_commitment_pools;
+
+ALTER TABLE rewards DROP COLUMN shareable;

--- a/migrations/014_shareable_rewards.up.sql
+++ b/migrations/014_shareable_rewards.up.sql
@@ -1,0 +1,59 @@
+-- Shared / family reward goals: multiple kids can pool points toward one
+-- shareable reward (think: family Minecraft purchase) and see what each
+-- person has chipped in. Each kid keeps a personal commitment slot too —
+-- shared participation is additive.
+--
+-- Modelling:
+--   * rewards.shareable = 1 marks a reward as poolable. The first kid to
+--     commit creates a shared_commitment_pools row that snapshots the cost
+--     so admins changing the price can't punish savers mid-pool.
+--   * reward_commitments grows a nullable shared_pool_id. NULL = personal
+--     commitment (existing behaviour). Set = a kid's share of a pool.
+--   * The "one active commitment per user" partial unique index is relaxed:
+--     it now only covers personal commitments (shared_pool_id IS NULL), so a
+--     kid can have one personal goal AND join multiple shared pools.
+
+ALTER TABLE rewards ADD COLUMN shareable INTEGER NOT NULL DEFAULT 0
+    CHECK (shareable IN (0, 1));
+
+CREATE TABLE shared_commitment_pools (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reward_id INTEGER NOT NULL REFERENCES rewards(id),
+    target_cost INTEGER NOT NULL CHECK (target_cost > 0),
+    status TEXT NOT NULL CHECK (status IN ('active', 'redeemed', 'cancelled'))
+        DEFAULT 'active',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    redeemed_at DATETIME,
+    redeemed_by_user_id INTEGER REFERENCES users(id),
+    cancelled_at DATETIME
+);
+
+-- At most one active pool per reward at a time. Once redeemed/cancelled, a
+-- new pool can be opened for the same reward (next family Minecraft round).
+CREATE UNIQUE INDEX idx_shared_pools_one_active_per_reward
+    ON shared_commitment_pools(reward_id)
+    WHERE status = 'active';
+
+CREATE INDEX idx_shared_pools_status
+    ON shared_commitment_pools(status);
+
+ALTER TABLE reward_commitments ADD COLUMN shared_pool_id INTEGER
+    REFERENCES shared_commitment_pools(id);
+
+CREATE INDEX idx_reward_commitments_pool
+    ON reward_commitments(shared_pool_id)
+    WHERE shared_pool_id IS NOT NULL;
+
+-- Replace the "one active commitment per user" rule with one that only
+-- applies to personal commitments. Shared shares are unrestricted.
+DROP INDEX idx_reward_commitments_one_active;
+
+CREATE UNIQUE INDEX idx_reward_commitments_one_active_personal
+    ON reward_commitments(user_id)
+    WHERE status = 'active' AND shared_pool_id IS NULL;
+
+-- A user can have at most one active share in any given pool (rejoining
+-- after breaking restarts a fresh row but the prior is cancelled).
+CREATE UNIQUE INDEX idx_reward_commitments_one_active_share_per_pool
+    ON reward_commitments(user_id, shared_pool_id)
+    WHERE status = 'active' AND shared_pool_id IS NOT NULL;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { User, ScheduledChore, Chore, ChoreSchedule, PointsData, PointBalance, PendingCompletion, Reward, RewardAssignment, RewardRedemption, RewardCommitment, RedemptionHistory, UserStreakData, StreakRewardItem, ChoreTrigger, Webhook, WebhookDelivery, UserDecayConfig, APIToken } from './types';
+import type { User, ScheduledChore, Chore, ChoreSchedule, PointsData, PointBalance, PendingCompletion, Reward, RewardAssignment, RewardRedemption, RewardCommitment, SharedCommitmentPool, RedemptionHistory, UserStreakData, StreakRewardItem, ChoreTrigger, Webhook, WebhookDelivery, UserDecayConfig, APIToken } from './types';
 
 const API_BASE = '/api';
 
@@ -253,6 +253,7 @@ export const api = {
       }),
     break: (commitmentId: number) =>
       fetchWithAuth(`/commitments/${commitmentId}`, { method: 'DELETE' }),
+    getPool: (poolId: number) => fetchWithAuth<SharedCommitmentPool>(`/pools/${poolId}`),
   },
   streaks: {
     getForUser: (userId: number) => fetchWithAuth<UserStreakData>(`/users/${userId}/streak`),

--- a/web/src/components/admin/RewardsTab.tsx
+++ b/web/src/components/admin/RewardsTab.tsx
@@ -98,6 +98,7 @@ const RewardForm: React.FC<{
   const [icon, setIcon] = useState(reward?.icon || '');
   const [cost, setCost] = useState(reward?.cost?.toString() || '50');
   const [stock, setStock] = useState(reward?.stock?.toString() || '');
+  const [shareable, setShareable] = useState(reward?.shareable ?? false);
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -111,6 +112,7 @@ const RewardForm: React.FC<{
         cost: parseInt(cost) || 0,
         stock: stock ? parseInt(stock) : undefined,
         active: true,
+        shareable,
       };
       if (reward) {
         await api.rewards.update(reward.id, data);
@@ -157,6 +159,18 @@ const RewardForm: React.FC<{
             <label className={styles.label} title="Limit how many times this reward can be redeemed. Leave blank for unlimited.">Stock (blank = unlimited)</label>
             <input className={styles.input} type="number" min="0" value={stock} onChange={e => setStock(e.target.value)} placeholder="∞" />
           </div>
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} title="Shareable rewards become a family pool: multiple kids can save together and the cost is split based on each kid's contribution.">
+            <input
+              type="checkbox"
+              checked={shareable}
+              onChange={e => setShareable(e.target.checked)}
+              style={{ marginRight: '0.5rem' }}
+            />
+            Shareable / family goal — multiple kids can pool points together
+          </label>
         </div>
       </div>
 

--- a/web/src/pages/Dashboard.module.css
+++ b/web/src/pages/Dashboard.module.css
@@ -1216,6 +1216,48 @@
   gap: 0.75rem;
 }
 
+/* Shared family goal card uses a teal accent so it's visually distinct from
+   the kid's personal goal at a glance. */
+.goalCardShared {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.12), rgba(56, 189, 248, 0.08));
+  border-color: rgba(34, 211, 238, 0.3);
+}
+
+.contributorList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  margin-top: -0.25rem;
+}
+
+.contributorChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  font-weight: 600;
+}
+
+.contributorChip strong {
+  color: var(--text-primary);
+  font-weight: 800;
+}
+
+.contributorChipMe {
+  background: rgba(34, 211, 238, 0.18);
+  border-color: rgba(34, 211, 238, 0.35);
+  color: #a5f3fc;
+}
+
+.contributorChipMe strong {
+  color: white;
+}
+
 .goalHeader {
   display: flex;
   align-items: center;

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -179,9 +179,11 @@ export const Dashboard: React.FC = () => {
   const [redeemingId, setRedeemingId] = useState<number | null>(null);
   const [redeemedId, setRedeemedId] = useState<number | null>(null);
   const [savingTowardId, setSavingTowardId] = useState<number | null>(null);
-  const [contributeAmount, setContributeAmount] = useState<string>('');
-  const [contributing, setContributing] = useState(false);
-  const [breakingGoal, setBreakingGoal] = useState(false);
+  // Per-commitment input + in-flight state, keyed by commitment id, so
+  // multiple goal cards (personal + N shared) each have their own UI.
+  const [contributeAmounts, setContributeAmounts] = useState<Record<number, string>>({});
+  const [contributingIds, setContributingIds] = useState<Set<number>>(new Set());
+  const [breakingIds, setBreakingIds] = useState<Set<number>>(new Set());
   const [toast, setToast] = useState<string | null>(null);
   // Per-schedule-id "request in flight" flag. Prevents double-POSTs when a
   // kid double-taps a chore tile (common on touchscreens), and lets us grey
@@ -351,12 +353,22 @@ export const Dashboard: React.FC = () => {
     setTimeout(() => setToast(null), 3000);
   };
 
+  // Look up the kid's active commitment for a given reward (personal or
+  // shared share — at most one of either kind).
+  const findCommitmentForReward = (rewardId: number) =>
+    pointsData?.active_commitments.find(c => c.reward_id === rewardId) ?? null;
+
   const handleRedeem = async (reward: Reward) => {
     if (!pointsData) return;
-    const commitment = pointsData.active_commitment;
-    const isCommittedReward = commitment && commitment.reward_id === reward.id;
-    if (!isCommittedReward && pointsData.balance < reward.effective_cost) return;
-    if (isCommittedReward && commitment.amount_saved < commitment.target_cost) return;
+    const commitment = findCommitmentForReward(reward.id);
+    const isCommitted = !!commitment;
+    const fullyFunded = commitment?.pool
+      ? commitment.pool.amount_saved >= commitment.pool.target_cost
+      : commitment
+        ? commitment.amount_saved >= commitment.target_cost
+        : false;
+    if (!isCommitted && pointsData.balance < reward.effective_cost) return;
+    if (isCommitted && !fullyFunded) return;
     setRedeemingId(reward.id);
     try {
       await api.rewards.redeem(reward.id);
@@ -376,20 +388,24 @@ export const Dashboard: React.FC = () => {
     } catch (e) {
       console.error('Redeem error:', e);
       setRedeemingId(null);
-      showToast('Redemption failed — try again');
+      const msg = e instanceof APIError ? e.message : 'Redemption failed — try again';
+      showToast(msg);
     }
   };
 
   const handleSaveToward = async (reward: Reward) => {
     if (!pointsData) return;
-    if (pointsData.active_commitment) {
-      showToast('You already have an active goal — finish or change it first');
+    // Personal goals occupy a single slot; shared rewards stack freely.
+    if (!reward.shareable && pointsData.active_commitments.some(c => !c.shared_pool_id)) {
+      showToast('You already have a personal goal — finish or change it first');
       return;
     }
     setSavingTowardId(reward.id);
     try {
       await api.commitments.commit(reward.id, 0);
-      showToast(`Saving toward ${reward.icon || '🎁'} ${reward.name}!`);
+      showToast(reward.shareable
+        ? `Joined family goal: ${reward.icon || '🎁'} ${reward.name}!`
+        : `Saving toward ${reward.icon || '🎁'} ${reward.name}!`);
       await loadExtras();
     } catch (e) {
       console.error('Save toward error:', e);
@@ -400,9 +416,10 @@ export const Dashboard: React.FC = () => {
     }
   };
 
-  const handleContribute = async () => {
-    if (!pointsData?.active_commitment) return;
-    const amount = parseInt(contributeAmount, 10);
+  const handleContribute = async (commitmentId: number) => {
+    if (!pointsData) return;
+    const raw = contributeAmounts[commitmentId] ?? '';
+    const amount = parseInt(raw, 10);
     if (!Number.isFinite(amount) || amount <= 0) {
       showToast('Enter a number of points to add');
       return;
@@ -411,10 +428,10 @@ export const Dashboard: React.FC = () => {
       showToast(`You only have ${pointsData.balance} spendable`);
       return;
     }
-    setContributing(true);
+    setContributingIds(prev => new Set(prev).add(commitmentId));
     try {
-      await api.commitments.contribute(pointsData.active_commitment.id, amount);
-      setContributeAmount('');
+      await api.commitments.contribute(commitmentId, amount);
+      setContributeAmounts(prev => ({ ...prev, [commitmentId]: '' }));
       await loadExtras();
       showToast(`Saved ${amount} more!`);
     } catch (e) {
@@ -422,37 +439,52 @@ export const Dashboard: React.FC = () => {
       const msg = e instanceof APIError ? e.message : 'Could not save — try again';
       showToast(msg);
     } finally {
-      setContributing(false);
+      setContributingIds(prev => {
+        const next = new Set(prev);
+        next.delete(commitmentId);
+        return next;
+      });
     }
   };
 
-  const handleSetAutoContribute = async (percent: number) => {
-    if (!pointsData?.active_commitment) return;
+  const handleSetAutoContribute = async (commitmentId: number, percent: number) => {
     // Optimistic so the slider feels responsive.
-    setPointsData(prev => prev && prev.active_commitment
-      ? { ...prev, active_commitment: { ...prev.active_commitment, auto_contribute_percent: percent } }
-      : prev);
+    setPointsData(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        active_commitments: prev.active_commitments.map(c =>
+          c.id === commitmentId ? { ...c, auto_contribute_percent: percent } : c
+        ),
+      };
+    });
     try {
-      await api.commitments.setAutoContribute(pointsData.active_commitment.id, percent);
+      await api.commitments.setAutoContribute(commitmentId, percent);
     } catch (e) {
       console.error('Auto-contribute error:', e);
       await loadExtras();
     }
   };
 
-  const handleBreakCommitment = async () => {
-    if (!pointsData?.active_commitment) return;
-    if (!window.confirm('Stop saving? Your saved points will go back to your spendable balance.')) return;
-    setBreakingGoal(true);
+  const handleBreakCommitment = async (commitmentId: number, isShared: boolean) => {
+    const msg = isShared
+      ? 'Leave this family goal? Your contribution will come back to your spendable balance.'
+      : 'Stop saving? Your saved points will go back to your spendable balance.';
+    if (!window.confirm(msg)) return;
+    setBreakingIds(prev => new Set(prev).add(commitmentId));
     try {
-      await api.commitments.break(pointsData.active_commitment.id);
+      await api.commitments.break(commitmentId);
       await loadExtras();
-      showToast('Goal cancelled — points are back in your balance');
+      showToast(isShared ? 'Left family goal — your share is back' : 'Goal cancelled — points are back in your balance');
     } catch (e) {
       console.error('Break commitment error:', e);
       showToast('Could not cancel goal — try again');
     } finally {
-      setBreakingGoal(false);
+      setBreakingIds(prev => {
+        const next = new Set(prev);
+        next.delete(commitmentId);
+        return next;
+      });
     }
   };
 
@@ -903,25 +935,35 @@ export const Dashboard: React.FC = () => {
     );
   };
 
-  const renderGoalCard = () => {
-    const commitment = pointsData?.active_commitment;
-    if (!commitment) return null;
-    const pct = Math.min(100, Math.round((commitment.amount_saved / commitment.target_cost) * 100));
-    const fullyFunded = commitment.amount_saved >= commitment.target_cost;
-    const remaining = Math.max(0, commitment.target_cost - commitment.amount_saved);
+  // Render one commitment card. Personal and shared use the same shape; for
+  // shared, progress and "remaining" come from the pool (so the bar reflects
+  // siblings' contributions too) and a contributor leaderboard sits at the
+  // bottom.
+  const renderGoalCard = (commitment: import('../types').RewardCommitment) => {
+    const isShared = !!commitment.pool;
+    const target = isShared ? commitment.pool!.target_cost : commitment.target_cost;
+    const totalSaved = isShared ? commitment.pool!.amount_saved : commitment.amount_saved;
+    const myShare = commitment.amount_saved;
+    const pct = target > 0 ? Math.min(100, Math.round((totalSaved / target) * 100)) : 0;
+    const fullyFunded = totalSaved >= target;
+    const remaining = Math.max(0, target - totalSaved);
+    const contributing = contributingIds.has(commitment.id);
+    const breaking = breakingIds.has(commitment.id);
+    const contributeAmount = contributeAmounts[commitment.id] ?? '';
+
     return (
-      <div className={styles.goalCard}>
+      <div key={commitment.id} className={clsx(styles.goalCard, isShared && styles.goalCardShared)}>
         <div className={styles.goalHeader}>
-          <div className={styles.goalIcon}>{commitment.reward_icon || '🎯'}</div>
+          <div className={styles.goalIcon}>{commitment.reward_icon || (isShared ? '👨‍👩‍👧' : '🎯')}</div>
           <div className={styles.goalTitleBlock}>
-            <div className={styles.goalLabel}>Saving toward</div>
+            <div className={styles.goalLabel}>{isShared ? 'Family goal' : 'Saving toward'}</div>
             <div className={styles.goalName}>{commitment.reward_name}</div>
           </div>
           {fullyFunded && <span className={styles.goalBadge}>Ready!</span>}
         </div>
         <div className={styles.goalAmounts}>
-          <span><strong>{commitment.amount_saved}</strong> / {commitment.target_cost} pts</span>
-          <span>{fullyFunded ? 'Fully funded 🎉' : `${remaining} to go`}</span>
+          <span><strong>{totalSaved}</strong> / {target} pts</span>
+          <span>{fullyFunded ? (isShared ? 'Tap redeem 🎉' : 'Fully funded 🎉') : `${remaining} to go`}</span>
         </div>
         <div className={styles.goalProgressTrack}>
           <div
@@ -929,6 +971,19 @@ export const Dashboard: React.FC = () => {
             style={{ width: `${pct}%` }}
           />
         </div>
+
+        {isShared && commitment.pool?.contributors && commitment.pool.contributors.length > 0 && (
+          <div className={styles.contributorList}>
+            {commitment.pool.contributors.map(c => (
+              <span
+                key={c.user_id}
+                className={clsx(styles.contributorChip, c.user_id === user?.id && styles.contributorChipMe)}
+              >
+                {c.user_id === user?.id ? 'You' : c.user_name}: <strong>{c.amount_saved}</strong>
+              </span>
+            ))}
+          </div>
+        )}
 
         <div className={styles.goalAuto}>
           <PiggyBank size={14} />
@@ -939,7 +994,7 @@ export const Dashboard: React.FC = () => {
             max={100}
             step={5}
             value={commitment.auto_contribute_percent}
-            onChange={e => handleSetAutoContribute(parseInt(e.target.value, 10))}
+            onChange={e => handleSetAutoContribute(commitment.id, parseInt(e.target.value, 10))}
             className={styles.goalAutoSlider}
           />
           <span className={styles.goalAutoValue}>{commitment.auto_contribute_percent}%</span>
@@ -953,12 +1008,12 @@ export const Dashboard: React.FC = () => {
               max={pointsData?.balance ?? 0}
               placeholder={`Add points (max ${pointsData?.balance ?? 0})`}
               value={contributeAmount}
-              onChange={e => setContributeAmount(e.target.value)}
+              onChange={e => setContributeAmounts(prev => ({ ...prev, [commitment.id]: e.target.value }))}
               className={styles.goalContributeInput}
             />
             <button
               className={clsx(styles.goalBtn, styles.goalBtnPrimary)}
-              onClick={handleContribute}
+              onClick={() => handleContribute(commitment.id)}
               disabled={contributing || !contributeAmount}
               style={{ flex: '0 0 auto', minWidth: 90 }}
             >
@@ -982,20 +1037,26 @@ export const Dashboard: React.FC = () => {
           )}
           <button
             className={clsx(styles.goalBtn, styles.goalBtnDanger)}
-            onClick={handleBreakCommitment}
-            disabled={breakingGoal}
+            onClick={() => handleBreakCommitment(commitment.id, isShared)}
+            disabled={breaking}
           >
-            <X size={14} /> Stop saving
+            <X size={14} /> {isShared ? 'Leave goal' : 'Stop saving'}
           </button>
         </div>
       </div>
     );
   };
 
+  const renderGoalCards = () => {
+    const list = pointsData?.active_commitments ?? [];
+    if (list.length === 0) return null;
+    return <>{list.map(c => renderGoalCard(c))}</>;
+  };
+
   const renderRewardsView = () => {
     const balance = pointsData?.balance ?? 0;
     const committed = pointsData?.committed ?? 0;
-    const commitment = pointsData?.active_commitment;
+    const hasPersonalGoal = (pointsData?.active_commitments ?? []).some(c => !c.shared_pool_id);
 
     return (
       <div className={styles.rewardsView}>
@@ -1007,7 +1068,7 @@ export const Dashboard: React.FC = () => {
           </span>
         </div>
 
-        {renderGoalCard()}
+        {renderGoalCards()}
 
         {rewards.length === 0 ? (
           <div className={styles.empty}>
@@ -1018,21 +1079,36 @@ export const Dashboard: React.FC = () => {
         ) : (
           <div className={styles.rewardsGrid}>
             {rewards.map(reward => {
-              const isCommittedReward = !!(commitment && commitment.reward_id === reward.id);
-              const canAfford = balance >= reward.effective_cost;
-              const fullyFunded = isCommittedReward && commitment!.amount_saved >= commitment!.target_cost;
+              const commitment = findCommitmentForReward(reward.id);
+              const isCommittedReward = !!commitment;
+              const isShared = reward.shareable;
+              const target = commitment?.pool ? commitment.pool.target_cost : (commitment?.target_cost ?? reward.effective_cost);
+              const totalSaved = commitment?.pool ? commitment.pool.amount_saved : (commitment?.amount_saved ?? 0);
+              const fullyFunded = isCommittedReward && totalSaved >= target;
+              const canAfford = !isShared && balance >= reward.effective_cost;
               const outOfStock = reward.stock !== null && reward.stock !== undefined && reward.stock <= 0;
               const isRedeeming = redeemingId === reward.id;
-              const isSaving = savingTowardId === reward.id;
-              const showSaveToward = !commitment && reward.effective_cost > balance;
+              const isSavingToward = savingTowardId === reward.id;
+              // Personal: show "Save toward" only if not affordable and the kid
+              // has no personal goal yet. Shared: show "Join family goal" if
+              // the kid hasn't joined this pool yet — independent of personal.
+              const showSaveToward = isShared
+                ? !isCommittedReward && !outOfStock
+                : !isCommittedReward && !hasPersonalGoal && reward.effective_cost > balance && !outOfStock;
+              const redeemEnabled = isShared
+                ? fullyFunded
+                : isCommittedReward
+                  ? fullyFunded
+                  : canAfford;
 
               return (
-                <div key={reward.id} className={clsx(styles.rewardCard, !canAfford && !isCommittedReward && styles.rewardCardLocked)}>
+                <div key={reward.id} className={clsx(styles.rewardCard, !redeemEnabled && !isCommittedReward && styles.rewardCardLocked)}>
                   {reward.icon && <div className={styles.rewardIcon}>{reward.icon}</div>}
                   <div className={styles.rewardInfo}>
                     <h3 className={styles.rewardName}>
                       {reward.name}
-                      {isCommittedReward && <> <span className={styles.goalBadge}><Target size={10} /> goal</span></>}
+                      {isShared && <> <span className={styles.goalBadge}><Users size={10} /> family</span></>}
+                      {isCommittedReward && !isShared && <> <span className={styles.goalBadge}><Target size={10} /> goal</span></>}
                     </h3>
                     {reward.description && (
                       <p className={styles.rewardDesc}>{reward.description}</p>
@@ -1052,10 +1128,10 @@ export const Dashboard: React.FC = () => {
                     <button
                       className={clsx(
                         styles.redeemBtn,
-                        ((isCommittedReward && fullyFunded) || (!isCommittedReward && canAfford)) && !outOfStock && styles.redeemBtnActive,
+                        redeemEnabled && !outOfStock && styles.redeemBtnActive,
                         redeemedId === reward.id && styles.redeemBtnSuccess
                       )}
-                      disabled={(isCommittedReward ? !fullyFunded : !canAfford) || outOfStock || isRedeeming || redeemedId === reward.id}
+                      disabled={!redeemEnabled || outOfStock || isRedeeming || redeemedId === reward.id}
                       onClick={() => handleRedeem(reward)}
                     >
                       {redeemedId === reward.id
@@ -1065,18 +1141,24 @@ export const Dashboard: React.FC = () => {
                           : outOfStock
                             ? 'Gone'
                             : isCommittedReward
-                              ? (fullyFunded ? 'Redeem' : `${commitment!.amount_saved}/${commitment!.target_cost}`)
+                              ? (fullyFunded ? 'Redeem' : `${totalSaved}/${target}`)
                               : canAfford
                                 ? 'Redeem'
-                                : `Need ${reward.effective_cost - balance}`}
+                                : isShared
+                                  ? 'Family goal'
+                                  : `Need ${reward.effective_cost - balance}`}
                     </button>
-                    {showSaveToward && !outOfStock && (
+                    {showSaveToward && (
                       <button
                         className={styles.saveTowardBtn}
                         onClick={() => handleSaveToward(reward)}
-                        disabled={isSaving}
+                        disabled={isSavingToward}
                       >
-                        {isSaving ? '...' : <><Target size={12} /> Save toward</>}
+                        {isSavingToward
+                          ? '...'
+                          : isShared
+                            ? <><Users size={12} /> Join goal</>
+                            : <><Target size={12} /> Save toward</>}
                       </button>
                     )}
                   </div>
@@ -1176,35 +1258,44 @@ export const Dashboard: React.FC = () => {
     </div>
   );
 
-  // Lightweight banner that nudges the kid toward their goal from the daily
-  // view. Tap it to jump to the rewards tab where they can save more or
-  // redeem when fully funded.
+  // Lightweight banner that nudges the kid toward each of their goals from
+  // the daily view. One row per active commitment (personal first, shared
+  // shares after). Tap to jump to the rewards tab.
   const renderGoalBanner = () => {
-    const c = pointsData?.active_commitment;
-    if (!c) return null;
-    const pct = Math.min(100, Math.round((c.amount_saved / c.target_cost) * 100));
-    const fullyFunded = c.amount_saved >= c.target_cost;
+    const list = pointsData?.active_commitments ?? [];
+    if (list.length === 0) return null;
     return (
-      <div className={styles.goalCard} onClick={() => setView('rewards')} role="button" tabIndex={0}>
-        <div className={styles.goalHeader}>
-          <div className={styles.goalIcon}>{c.reward_icon || '🎯'}</div>
-          <div className={styles.goalTitleBlock}>
-            <div className={styles.goalLabel}>Saving toward</div>
-            <div className={styles.goalName}>{c.reward_name}</div>
-          </div>
-          {fullyFunded && <span className={styles.goalBadge}>Ready!</span>}
-        </div>
-        <div className={styles.goalAmounts}>
-          <span><strong>{c.amount_saved}</strong> / {c.target_cost} pts</span>
-          <span>{fullyFunded ? 'Tap to redeem 🎉' : `${c.target_cost - c.amount_saved} to go`}</span>
-        </div>
-        <div className={styles.goalProgressTrack}>
-          <div
-            className={clsx(styles.goalProgressFill, fullyFunded && styles.goalProgressFillDone)}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-      </div>
+      <>
+        {list.map(c => {
+          const isShared = !!c.pool;
+          const target = isShared ? c.pool!.target_cost : c.target_cost;
+          const totalSaved = isShared ? c.pool!.amount_saved : c.amount_saved;
+          const pct = target > 0 ? Math.min(100, Math.round((totalSaved / target) * 100)) : 0;
+          const fullyFunded = totalSaved >= target;
+          return (
+            <div key={c.id} className={clsx(styles.goalCard, isShared && styles.goalCardShared)} onClick={() => setView('rewards')} role="button" tabIndex={0}>
+              <div className={styles.goalHeader}>
+                <div className={styles.goalIcon}>{c.reward_icon || (isShared ? '👨‍👩‍👧' : '🎯')}</div>
+                <div className={styles.goalTitleBlock}>
+                  <div className={styles.goalLabel}>{isShared ? 'Family goal' : 'Saving toward'}</div>
+                  <div className={styles.goalName}>{c.reward_name}</div>
+                </div>
+                {fullyFunded && <span className={styles.goalBadge}>Ready!</span>}
+              </div>
+              <div className={styles.goalAmounts}>
+                <span><strong>{totalSaved}</strong> / {target} pts{isShared && c.amount_saved !== totalSaved ? ` · you: ${c.amount_saved}` : ''}</span>
+                <span>{fullyFunded ? 'Tap to redeem 🎉' : `${target - totalSaved} to go`}</span>
+              </div>
+              <div className={styles.goalProgressTrack}>
+                <div
+                  className={clsx(styles.goalProgressFill, fullyFunded && styles.goalProgressFillDone)}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </>
     );
   };
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -261,6 +261,8 @@ export interface RewardCommitment {
   amount_saved: number;
   auto_contribute_percent: number;
   status: 'active' | 'redeemed' | 'cancelled';
+  shared_pool_id?: number;
+  pool?: SharedCommitmentPool;
   created_at: string;
   redeemed_at?: string;
   cancelled_at?: string;
@@ -269,7 +271,7 @@ export interface RewardCommitment {
 export interface PointsData {
   balance: number;
   committed: number;
-  active_commitment: RewardCommitment | null;
+  active_commitments: RewardCommitment[];
   transactions: PointTransaction[];
 }
 
@@ -294,9 +296,30 @@ export interface Reward {
   effective_cost: number;
   stock?: number;
   active: boolean;
+  shareable: boolean;
   created_by: number;
   created_at: string;
   assignments?: RewardAssignment[];
+}
+
+export interface PoolContributor {
+  user_id: number;
+  user_name: string;
+  avatar_url?: string;
+  amount_saved: number;
+}
+
+export interface SharedCommitmentPool {
+  id: number;
+  reward_id: number;
+  reward_name?: string;
+  reward_icon?: string;
+  target_cost: number;
+  amount_saved: number;
+  status: 'active' | 'redeemed' | 'cancelled';
+  contributors?: PoolContributor[];
+  created_at: string;
+  redeemed_at?: string;
 }
 
 export interface RewardRedemption {


### PR DESCRIPTION
## Summary

Adds **shareable rewards** so multiple kids can pool points toward one family goal (the impetus: my kids want to chip in on Minecraft, but nobody wants to be the one who spends all *their* points on a shared purchase). When a reward is marked shareable in the admin UI, kids see a "Join family goal" button instead of "Save toward"; the pool fills as everyone contributes; anyone in the pool can hit redeem when it's fully funded; each kid is debited only what they put in.

### Schema (migration 014)
- `rewards.shareable` (bool, default false).
- New `shared_commitment_pools` table, target cost snapshotted on first join.
- `reward_commitments.shared_pool_id` (nullable). NULL = personal goal (existing behavior).
- Relaxed the "one active commitment per user" partial unique index to apply only when `shared_pool_id IS NULL`, so a kid can have one personal goal **and** participate in any number of shared pools simultaneously.

### Store / API
- `CreateCommitment` branches on `reward.shareable` — creates the pool on first join, joins existing one for subsequent kids.
- `RedeemReward` for shareable rewards iterates contributors, emits per-kid `goal_break` + `reward_redeem` + `reward_redemption` rows sized to each kid's saved share. Stock decrements once. Pool marked redeemed.
- `ContributeToCommitment` caps shared contributions at the **pool's** remaining target (so the last kid in can't push past 100%).
- `BreakCommitment` for a shared share refunds only that kid's portion; the pool stays active for other kids.
- `applyAutoContributeTx` iterates all active commitments (personal first, shared by join order) and apportions pct% per goal, capped per goal and per remaining credit.
- `UndoRedemption` per-kid for shared (refunds that kid, leaves pool redeemed).
- `GetUserPoints` now returns `active_commitments[]` instead of singular `active_commitment`. Each shared one carries an embedded `pool` with the contributor leaderboard.
- New endpoint: `GET /api/pools/{id}` for refresh after siblings contribute.

### UI (kid Dashboard)
- Goal-card stack instead of one card: personal first, then shared family goals (teal accent so they're visually distinct).
- Each shared card shows the pool progress bar + a contributor chip row ("**You**: 75 · Alice: 120 · Bob: 50").
- Auto-save slider per goal — splits chore credits across both personal and shared goals.
- Reward grid offers "Join goal" on shareable cards (regardless of personal slot status); "Save toward" stays gated on the single personal slot.

### Admin
- New "Shareable / family goal" checkbox in the reward create/edit form.

### Tests
6 new store tests for shared pools (join, contribute cap, redemption per-kid debit, redeem-not-funded guard, leave-only-refunds-mine, auto-contribute stacks personal+shared). All previous commitment + reward tests still pass.

## Test plan
- [x] `go test ./...` clean across the board
- [x] `npx tsc --noEmit` and `npm run build` clean
- [ ] Manual: admin marks a reward shareable, two kids join, both contribute, one hits redeem, history shows correct per-kid amounts
- [ ] Manual: kid saving for a personal goal also joins family goal, completes a chore, auto-contribute splits across both
- [ ] Manual: a kid leaves a partial pool — pool retains other kids' contributions
- [ ] Manual: admin raises the price after kids start saving — pool target stays at the snapshot

https://claude.ai/code/session_01VJZ4BL7QrkW94LqpWNHpJR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJZ4BL7QrkW94LqpWNHpJR)_