### PR TITLE
Fix #41: Install missing native runtime libraries in LiteRT Containerfile

### DIFF
--- a/litert/Containerfile
+++ b/litert/Containerfile
@@ -1,5 +1,9 @@
 FROM python:3.12-slim
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends libvulkan1 libegl1 libgles2 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir litert-lm-api huggingface_hub
 
 WORKDIR /app


### PR DESCRIPTION
Closes #41 by installing libvulkan1, libegl1, and libgles2 in the LiteRT Containerfile, resolving the missing library startup error.