### PR TITLE
feat(backend): implement required chore gating for core chore points

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2301,6 +2301,129 @@ func TestRequiredCompletionOpensBonusGate(t *testing.T) {
 	}
 }
 
+// TestRequiredChoresGateCoreChorePoints verifies that core chores are gated by
+// required chores on the same day, and that completing a required chore
+// retroactively credits both core and bonus chores that were capped at 0.
+func TestRequiredChoresGateCoreChorePoints(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	// 1. Required chore worth 5 points
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Required Chore", "category": "required", "points_value": 5,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	// 2. Core chore worth 10 points
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Core Chore", "category": "core", "points_value": 10,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	// 3. Bonus chore worth 20 points
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title": "Bonus Chore", "category": "bonus", "points_value": 20,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/3/schedules", map[string]any{
+		"assigned_to": kidID,
+		"day_of_week": int(time.Now().Weekday()),
+	}, adminHeaders())
+
+	// Set up a reward and commitment (50% auto-contribute)
+	env.request(t, "POST", "/api/rewards", map[string]any{
+		"name": "Toy", "cost": 100,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/rewards/1/commit", map[string]any{
+		"auto_contribute_percent": 50,
+	}, childHeaders(kidID))
+
+	today := time.Now().Format(model.DateFormat)
+
+	// Complete Core first -> required is pending, so core should credit 0.
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 balance (core points gated by incomplete required chore), got %v", pts["balance"])
+	}
+	if pts["committed"].(float64) != 0 {
+		t.Fatalf("expected 0 committed (no points gained), got %v", pts["committed"])
+	}
+
+	// Complete Bonus second -> required is pending, so bonus should credit 0.
+	env.expectStatus(t, "POST", "/api/schedules/3/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 balance (bonus gated), got %v", pts["balance"])
+	}
+
+	// Complete Required third -> this should:
+	// - award required points (5)
+	// - retroactively credit core points (10)
+	// - retroactively credit bonus points (20)
+	// Net balance earned: 35. With 50% auto-contribute, 17 points saved (5*0.5 + 10*0.5 + 20*0.5 = 2 + 5 + 10 = 17)
+	// and 18 points left in spendable balance.
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 18 {
+		t.Fatalf("expected 18 spendable balance (35 total - 17 saved), got %v", pts["balance"])
+	}
+	if pts["committed"].(float64) != 17 {
+		t.Fatalf("expected 17 points saved to goal, got %v", pts["committed"])
+	}
+
+	// Uncheck and recheck the core chore - should not double credit
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/2/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	// Unchecking the 10-point core chore refunds the 5 points that were committed to the goal
+	// and debits 5 points from spendable. Balance becomes 18 - 5 = 13. Committed becomes 17 - 5 = 12.
+	if pts["balance"].(float64) != 13 {
+		t.Fatalf("expected 13 spendable after unchecking core chore, got %v", pts["balance"])
+	}
+	if pts["committed"].(float64) != 12 {
+		t.Fatalf("expected 12 committed after unchecking core chore, got %v", pts["committed"])
+	}
+
+	// Recheck core chore -> should revive and re-evaluate gate, crediting the 10 points (5 spendable, 5 committed)
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 18 {
+		t.Fatalf("expected 18 spendable after rechecking core chore, got %v", pts["balance"])
+	}
+	if pts["committed"].(float64) != 17 {
+		t.Fatalf("expected 17 committed after rechecking core chore, got %v", pts["committed"])
+	}
+}
+
+
 // =================== BCRYPT PASSCODE TESTS ===================
 
 func TestBcryptPasscodeRoundTrip(t *testing.T) {

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -460,6 +460,9 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 					if _, err := h.store.ReverseUncompleteDebits(r.Context(), existing.ID); err != nil {
 						log.Printf("error reversing uncomplete debits for completion %d: %v", existing.ID, err)
 					}
+					if err := h.store.ReverseAutoContributeReversals(r.Context(), existing.ID); err != nil {
+						log.Printf("error reversing auto-contribute reversals for completion %d: %v", existing.ID, err)
+					}
 					// Bonus chores that were originally credited 0 points (because
 					// required/core weren't done yet) can now qualify if the kid has
 					// since finished the rest of the day. Re-run the gate and credit
@@ -468,6 +471,18 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 					// CLAUDE.md). We only ever credit the delta, so stacking
 					// unchecks/rechecks can't multi-credit the bonus.
 					reviveChore, _ := h.store.GetChore(r.Context(), schedule.ChoreID)
+					if reviveChore != nil && reviveChore.Category == model.CategoryCore {
+						if h.shouldAwardCorePoints(r.Context(), existing.CompletedBy, req.CompletionDate) {
+							fullPts, _ := h.store.GetChorePointsForSchedule(r.Context(), scheduleID)
+							alreadyCredited, _ := h.store.GetNetPointsForCompletion(r.Context(), existing.ID)
+							delta := fullPts - alreadyCredited
+							if delta > 0 {
+								if err := h.store.CreditChorePoints(r.Context(), existing.CompletedBy, existing.ID, delta); err != nil {
+									log.Printf("error crediting core delta on revive for completion %d: %v", existing.ID, err)
+								}
+							}
+						}
+					}
 					if reviveChore != nil && reviveChore.Category == model.CategoryBonus {
 						if h.shouldAwardBonusPoints(r.Context(), existing.CompletedBy, req.CompletionDate) {
 							fullPts, _ := h.store.GetChorePointsForSchedule(r.Context(), scheduleID)
@@ -640,6 +655,13 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		// Credit or penalize points based on expiry status
 		pts, _ = h.store.GetChorePointsForSchedule(r.Context(), scheduleID)
 
+		// Core chore points only count once required chores are complete
+		if chore != nil && chore.Category == model.CategoryCore {
+			if !h.shouldAwardCorePoints(r.Context(), completedBy, req.CompletionDate) {
+				pts = 0
+			}
+		}
+
 		// Bonus chore points only count once required + core chores are complete
 		if chore != nil && chore.Category == model.CategoryBonus {
 			if !h.shouldAwardBonusPoints(r.Context(), completedBy, req.CompletionDate) {
@@ -662,6 +684,11 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 			if err := h.store.CreditChorePoints(r.Context(), completedBy, completion.ID, pts); err != nil {
 				log.Printf("error crediting chore points for user %d completion %d: %v", completedBy, completion.ID, err)
 			}
+		}
+
+		// Completing a required chore can be the event that opens the core gate.
+		if chore != nil && chore.Category == model.CategoryRequired {
+			h.creditPendingCorePoints(r.Context(), completedBy, req.CompletionDate)
 		}
 
 		// Completing a required/core chore can be the event that opens the
@@ -897,6 +924,13 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 		pts, _ = h.store.GetChorePointsForSchedule(r.Context(), schedule.ID)
 		chore, _ := h.store.GetChore(r.Context(), schedule.ChoreID)
 
+		// Core logic
+		if chore != nil && chore.Category == model.CategoryCore {
+			if !h.shouldAwardCorePoints(r.Context(), completion.CompletedBy, completion.CompletionDate) {
+				pts = 0
+			}
+		}
+
 		// Bonus logic
 		if chore != nil && chore.Category == model.CategoryBonus {
 			if !h.shouldAwardBonusPoints(r.Context(), completion.CompletedBy, completion.CompletionDate) {
@@ -908,6 +942,11 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 			if err := h.store.CreditChorePoints(r.Context(), completion.CompletedBy, completion.ID, pts); err != nil {
 				log.Printf("error crediting chore points for user %d completion %d: %v", completion.CompletedBy, completion.ID, err)
 			}
+		}
+
+		// Approving a required completion can be the event that opens the core gate.
+		if chore != nil && chore.Category == model.CategoryRequired {
+			h.creditPendingCorePoints(r.Context(), completion.CompletedBy, completion.CompletionDate)
 		}
 
 		// Approving a required/core completion can be the event that opens
@@ -1300,6 +1339,21 @@ func (h *ChoreHandler) shouldAwardBonusPoints(ctx context.Context, userID int64,
 	return true
 }
 
+// shouldAwardCorePoints returns true if all required chores for the
+// given user and date are complete, meaning core points should be awarded.
+func (h *ChoreHandler) shouldAwardCorePoints(ctx context.Context, userID int64, date string) bool {
+	todayChores, err := h.store.GetScheduledChoresForUser(ctx, userID, []string{date}, time.Now())
+	if err != nil {
+		return false
+	}
+	for _, c := range todayChores {
+		if !c.Completed && c.Category == model.CategoryRequired {
+			return false
+		}
+	}
+	return true
+}
+
 // creditPendingBonusPoints retroactively credits approved bonus completions
 // for the given user/date that were capped at 0 points because the
 // required/core gate was closed at the time of their approval. Call after an
@@ -1343,3 +1397,47 @@ func (h *ChoreHandler) creditPendingBonusPoints(ctx context.Context, userID int6
 		}
 	}
 }
+
+// creditPendingCorePoints retroactively credits approved core completions
+// for the given user/date that were capped at 0 points because the
+// required gate was closed at the time of their approval. Call after an
+// event that can open the gate (a required chore transitioning to approved).
+// No-op if the gate is still closed. Only the delta between the chore's
+// full value and what's already on the completion is credited.
+func (h *ChoreHandler) creditPendingCorePoints(ctx context.Context, userID int64, date string) {
+	if !h.shouldAwardCorePoints(ctx, userID, date) {
+		return
+	}
+	scheduled, err := h.store.GetScheduledChoresForUser(ctx, userID, []string{date}, time.Now())
+	if err != nil {
+		log.Printf("error fetching scheduled chores for core reevaluation user %d date %s: %v", userID, date, err)
+		return
+	}
+	for _, sc := range scheduled {
+		if sc.Category != model.CategoryCore || sc.CompletionID == nil {
+			continue
+		}
+		// Only approved completions get points; pending completions
+		// are credited when the admin approves them.
+		if sc.CompletionStatus == nil || *sc.CompletionStatus != model.StatusApproved {
+			continue
+		}
+		fullPts, err := h.store.GetChorePointsForSchedule(ctx, sc.ScheduleID)
+		if err != nil {
+			log.Printf("error fetching points for schedule %d: %v", sc.ScheduleID, err)
+			continue
+		}
+		alreadyCredited, err := h.store.GetNetPointsForCompletion(ctx, *sc.CompletionID)
+		if err != nil {
+			log.Printf("error fetching net points for completion %d: %v", *sc.CompletionID, err)
+			continue
+		}
+		delta := fullPts - alreadyCredited
+		if delta > 0 {
+			if err := h.store.CreditChorePoints(ctx, userID, *sc.CompletionID, delta); err != nil {
+				log.Printf("error crediting retroactive core points for user %d completion %d: %v", userID, *sc.CompletionID, err)
+			}
+		}
+	}
+}
+

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -457,6 +457,18 @@ func (s *Store) ReverseUncompleteDebits(ctx context.Context, completionID int64)
 	return reversed, nil
 }
 
+// ReverseAutoContributeReversals deletes any goal_break transactions that were
+// recorded to revert auto-contributions for the given completion ID. Used
+// when reviving a soft-deleted completion.
+func (s *Store) ReverseAutoContributeReversals(ctx context.Context, completionID int64) error {
+	revertNote := fmt.Sprintf("auto_revert:completion:%d", completionID)
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM point_transactions WHERE reference_id = ? AND reason = ? AND note = ?`,
+		completionID, model.ReasonGoalBreak, revertNote)
+	return err
+}
+
+
 func (s *Store) GetSchedule(ctx context.Context, id int64) (*model.ChoreSchedule, error) {
 	cs := &model.ChoreSchedule{}
 	err := s.db.QueryRowContext(ctx,


### PR DESCRIPTION
This PR gates core chore points behind completing all required chores on the same day. It also handles retroactively crediting core chore points once a required chore is completed or approved.