### PR TITLE
fix(e2e): target required chore in point transaction test to avoid point gating

### DIFF
--- a/e2e/tests/points.spec.ts
+++ b/e2e/tests/points.spec.ts
@@ -24,8 +24,8 @@ test.describe('Points System', () => {
     const today = new Date().toISOString().slice(0, 10);
     const chores = await apiGet(page, `/users/3/chores?view=daily&date=${today}`, 3);
 
-    // Find an incomplete chore
-    const incomplete = chores.find((c: any) => !c.completed && c.available);
+    // Find an incomplete required chore so points are awarded immediately without gating
+    const incomplete = chores.find((c: any) => !c.completed && c.available && c.category === 'required');
     if (!incomplete) return; // All done for today
 
     await page.request.post(`/api/schedules/${incomplete.schedule_id}/complete`, {


### PR DESCRIPTION
Closes #50

### Summary

In `e2e/tests/points.spec.ts`, the test `'completing a chore creates a point transaction'` was selecting the first available incomplete chore:
```typescript
const incomplete = chores.find((c: any) => !c.completed && c.available);
```

Because `GetScheduledChoresForUser` orders by `cs.available_at NULLS FIRST, c.category, c.title`, `bonus` and `core` chores without time locks come before `required` chores.

With required chore gating introduced in `e0134c5`, completing a `bonus` or `core` chore awards 0 points while required chores remain incomplete, so no entry was written to `point_transactions` and the test failed in CI.

### Changes
- Updated the chore lookup in `e2e/tests/points.spec.ts` to specifically target an incomplete `required` category chore so points and the corresponding point transaction are recorded immediately.