### PR TITLE
feat(auth): log PIN and passcode verification and update events

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 	"strings"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/liftedkilt/openchore/internal/config"
 	"github.com/liftedkilt/openchore/internal/store"
+	"github.com/liftedkilt/openchore/internal/webhook"
 )
 
 // writableSettings is the allowlist of setting keys that can be written via
@@ -25,11 +27,12 @@ var writableSettings = map[string]bool{
 }
 
 type AdminHandler struct {
-	store *store.Store
+	store      *store.Store
+	dispatcher *webhook.Dispatcher
 }
 
-func NewAdminHandler(s *store.Store) *AdminHandler {
-	return &AdminHandler{store: s}
+func NewAdminHandler(s *store.Store, dispatcher *webhook.Dispatcher) *AdminHandler {
+	return &AdminHandler{store: s, dispatcher: dispatcher}
 }
 
 type verifyPasscodeRequest struct {
@@ -49,9 +52,25 @@ func (h *AdminHandler) VerifyPasscode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ip := clientIP(r)
 	if err := bcrypt.CompareHashAndPassword([]byte(stored), []byte(req.Passcode)); err != nil {
+		log.Printf("auth: failed admin passcode attempt from %s", ip)
+		if h.dispatcher != nil {
+			h.dispatcher.Fire(webhook.EventAdminPasscodeFailed, map[string]any{
+				"ip_address": ip,
+				"user_agent": r.UserAgent(),
+			})
+		}
 		writeError(w, http.StatusUnauthorized, "incorrect passcode")
 		return
+	}
+
+	log.Printf("auth: admin passcode verified from %s", ip)
+	if h.dispatcher != nil {
+		h.dispatcher.Fire(webhook.EventAdminPasscodeVerified, map[string]any{
+			"ip_address": ip,
+			"user_agent": r.UserAgent(),
+		})
 	}
 
 	writeJSON(w, http.StatusOK, map[string]bool{"valid": true})
@@ -78,7 +97,15 @@ func (h *AdminHandler) UpdatePasscode(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to check passcode")
 		return
 	}
+	ip := clientIP(r)
 	if err := bcrypt.CompareHashAndPassword([]byte(stored), []byte(req.OldPasscode)); err != nil {
+		log.Printf("auth: failed admin passcode update attempt from %s", ip)
+		if h.dispatcher != nil {
+			h.dispatcher.Fire(webhook.EventAdminPasscodeFailed, map[string]any{
+				"ip_address": ip,
+				"user_agent": r.UserAgent(),
+			})
+		}
 		writeError(w, http.StatusUnauthorized, "incorrect current passcode")
 		return
 	}
@@ -92,6 +119,22 @@ func (h *AdminHandler) UpdatePasscode(w http.ResponseWriter, r *http.Request) {
 	if err := h.store.SetSetting(r.Context(), "admin_passcode", string(hashed)); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update passcode")
 		return
+	}
+
+	caller := UserFromContext(r.Context())
+	var actorID int64
+	var actorName string
+	if caller != nil {
+		actorID = caller.ID
+		actorName = caller.Name
+	}
+	log.Printf("auth: admin passcode changed by user %d (%s) from %s", actorID, actorName, ip)
+	if h.dispatcher != nil {
+		h.dispatcher.Fire(webhook.EventAdminPasscodeChanged, map[string]any{
+			"actor_id":   actorID,
+			"actor_name": actorName,
+			"ip_address": ip,
+		})
 	}
 
 	writeJSON(w, http.StatusOK, map[string]bool{"updated": true})

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3820,3 +3820,183 @@ func TestProfilePinAdminMustVerifyOwnCurrentPin(t *testing.T) {
 	env.expectStatus(t, "DELETE", "/api/users/1/pin",
 		map[string]any{"current_pin": "5678"}, adminHeaders(), http.StatusOK)
 }
+
+// =================== AUTH & PIN EVENT LOGGING / WEBHOOK TESTS ===================
+
+func TestAdminPasscodeWebhookEvents(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+
+	var mu sync.Mutex
+	var receivedEvents []string
+	var receivedPayloads []webhook.Payload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedEvents = append(receivedEvents, r.Header.Get("X-OpenChore-Event"))
+		body, _ := io.ReadAll(r.Body)
+		var p webhook.Payload
+		_ = json.Unmarshal(body, &p)
+		receivedPayloads = append(receivedPayloads, p)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Register webhook for all events
+	env.expectStatus(t, "POST", "/api/admin/webhooks", map[string]any{
+		"url":    ts.URL,
+		"events": "*",
+	}, adminHeaders(), http.StatusCreated)
+
+	// 1. Successful verification
+	env.expectStatus(t, "POST", "/api/admin/verify", map[string]any{
+		"passcode": "0000",
+	}, nil, http.StatusOK)
+
+	// 2. Failed verification
+	env.expectStatus(t, "POST", "/api/admin/verify", map[string]any{
+		"passcode": "9999",
+	}, nil, http.StatusUnauthorized)
+
+	// 3. Failed passcode update (wrong current passcode)
+	env.expectStatus(t, "PUT", "/api/admin/passcode", map[string]any{
+		"old_passcode": "wrong",
+		"new_passcode": "validpass1",
+	}, adminHeaders(), http.StatusUnauthorized)
+
+	// 4. Successful passcode update
+	env.expectStatus(t, "PUT", "/api/admin/passcode", map[string]any{
+		"old_passcode": "0000",
+		"new_passcode": "validpass1",
+	}, adminHeaders(), http.StatusOK)
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	expectedEvents := []string{
+		webhook.EventAdminPasscodeVerified,
+		webhook.EventAdminPasscodeFailed,
+		webhook.EventAdminPasscodeFailed,
+		webhook.EventAdminPasscodeChanged,
+	}
+
+	if len(receivedEvents) != len(expectedEvents) {
+		t.Fatalf("expected %d events, got %d: %v", len(expectedEvents), len(receivedEvents), receivedEvents)
+	}
+
+	for i, exp := range expectedEvents {
+		if receivedEvents[i] != exp {
+			t.Errorf("event %d: expected %q, got %q", i, exp, receivedEvents[i])
+		}
+	}
+
+	// Verify payloads never contain plaintext passcodes
+	for i, p := range receivedPayloads {
+		dataBytes, _ := json.Marshal(p.Data)
+		dataStr := string(dataBytes)
+		if strings.Contains(dataStr, "0000") || strings.Contains(dataStr, "validpass1") || strings.Contains(dataStr, "wrong") {
+			t.Errorf("payload %d leaks passcode in data: %s", i, dataStr)
+		}
+	}
+}
+
+func TestProfilePinWebhookEvents(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	var mu sync.Mutex
+	var receivedEvents []string
+	var receivedPayloads []webhook.Payload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedEvents = append(receivedEvents, r.Header.Get("X-OpenChore-Event"))
+		body, _ := io.ReadAll(r.Body)
+		var p webhook.Payload
+		_ = json.Unmarshal(body, &p)
+		receivedPayloads = append(receivedPayloads, p)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Register webhook for all events
+	env.expectStatus(t, "POST", "/api/admin/webhooks", map[string]any{
+		"url":    ts.URL,
+		"events": "*",
+	}, adminHeaders(), http.StatusCreated)
+
+	// 1. Initial PIN set
+	env.expectStatus(t, "PUT", fmt.Sprintf("/api/users/%d/pin", kidID), map[string]any{
+		"new_pin": "1234",
+	}, childHeaders(kidID), http.StatusOK)
+
+	// 2. Successful PIN verify
+	env.expectStatus(t, "POST", fmt.Sprintf("/api/users/%d/verify-pin", kidID), map[string]any{
+		"pin": "1234",
+	}, nil, http.StatusOK)
+
+	// 3. Failed PIN verify
+	env.expectStatus(t, "POST", fmt.Sprintf("/api/users/%d/verify-pin", kidID), map[string]any{
+		"pin": "0000",
+	}, nil, http.StatusUnauthorized)
+
+	// 4. Failed PIN change (wrong current_pin)
+	env.expectStatus(t, "PUT", fmt.Sprintf("/api/users/%d/pin", kidID), map[string]any{
+		"current_pin": "wrong",
+		"new_pin":     "5678",
+	}, childHeaders(kidID), http.StatusUnauthorized)
+
+	// 5. Successful PIN change
+	env.expectStatus(t, "PUT", fmt.Sprintf("/api/users/%d/pin", kidID), map[string]any{
+		"current_pin": "1234",
+		"new_pin":     "5678",
+	}, childHeaders(kidID), http.StatusOK)
+
+	// 6. Admin reset PIN (override)
+	env.expectStatus(t, "PUT", fmt.Sprintf("/api/users/%d/pin", kidID), map[string]any{
+		"new_pin": "9999",
+	}, adminHeaders(), http.StatusOK)
+
+	// 7. Admin clear PIN
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/users/%d/pin", kidID), nil, adminHeaders(), http.StatusOK)
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	expectedEvents := []string{
+		webhook.EventProfilePinChanged,
+		webhook.EventProfilePinVerified,
+		webhook.EventProfilePinFailed,
+		webhook.EventProfilePinFailed,
+		webhook.EventProfilePinChanged,
+		webhook.EventProfilePinChanged,
+		webhook.EventProfilePinCleared,
+	}
+
+	if len(receivedEvents) != len(expectedEvents) {
+		t.Fatalf("expected %d events, got %d: %v", len(expectedEvents), len(receivedEvents), receivedEvents)
+	}
+
+	for i, exp := range expectedEvents {
+		if receivedEvents[i] != exp {
+			t.Errorf("event %d: expected %q, got %q", i, exp, receivedEvents[i])
+		}
+	}
+
+	// Verify payloads never contain plaintext PINs
+	for i, p := range receivedPayloads {
+		dataBytes, _ := json.Marshal(p.Data)
+		dataStr := string(dataBytes)
+		if strings.Contains(dataStr, "1234") || strings.Contains(dataStr, "5678") || strings.Contains(dataStr, "9999") {
+			t.Errorf("payload %d leaks PIN in data: %s", i, dataStr)
+		}
+	}
+}
+

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -9,6 +9,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -38,4 +40,22 @@ func intPtrOrZero(p *int) int {
 		return 0
 	}
 	return *p
+}
+
+// clientIP extracts the client's IP address from headers (X-Forwarded-For, X-Real-IP) or RemoteAddr.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 && strings.TrimSpace(parts[0]) != "" {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -18,9 +18,9 @@ func NewRouter(s *store.Store, dispatcher *webhook.Dispatcher) (*chi.Mux, *Chore
 
 	discordNotifier := discord.NewNotifier(s)
 
-	users := NewUserHandler(s)
+	users := NewUserHandler(s, dispatcher)
 	chores := NewChoreHandler(s, dispatcher, discordNotifier)
-	admin := NewAdminHandler(s)
+	admin := NewAdminHandler(s, dispatcher)
 	points := NewPointsHandler(s)
 	rewards := NewRewardHandler(s, dispatcher)
 	streaks := NewStreakHandler(s)

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -8,14 +9,16 @@ import (
 
 	"github.com/liftedkilt/openchore/internal/model"
 	"github.com/liftedkilt/openchore/internal/store"
+	"github.com/liftedkilt/openchore/internal/webhook"
 )
 
 type UserHandler struct {
-	store *store.Store
+	store      *store.Store
+	dispatcher *webhook.Dispatcher
 }
 
-func NewUserHandler(s *store.Store) *UserHandler {
-	return &UserHandler{store: s}
+func NewUserHandler(s *store.Store, dispatcher *webhook.Dispatcher) *UserHandler {
+	return &UserHandler{store: s, dispatcher: dispatcher}
 }
 
 func (h *UserHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -399,10 +402,36 @@ func (h *UserHandler) VerifyPin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "profile has no pin")
 		return
 	}
+
+	ip := clientIP(r)
+	targetUser, _ := h.store.GetUser(r.Context(), id)
+	targetName := ""
+	if targetUser != nil {
+		targetName = targetUser.Name
+	}
+
 	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Pin)); err != nil {
+		log.Printf("auth: failed pin attempt for user %d (%s) from %s", id, targetName, ip)
+		if h.dispatcher != nil {
+			h.dispatcher.Fire(webhook.EventProfilePinFailed, map[string]any{
+				"user_id":    id,
+				"user_name":  targetName,
+				"ip_address": ip,
+			})
+		}
 		writeError(w, http.StatusUnauthorized, "incorrect pin")
 		return
 	}
+
+	log.Printf("auth: user %d (%s) pin verified from %s", id, targetName, ip)
+	if h.dispatcher != nil {
+		h.dispatcher.Fire(webhook.EventProfilePinVerified, map[string]any{
+			"user_id":    id,
+			"user_name":  targetName,
+			"ip_address": ip,
+		})
+	}
+
 	writeJSON(w, http.StatusOK, map[string]bool{"valid": true})
 }
 
@@ -447,25 +476,36 @@ func (h *UserHandler) SetPin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ip := clientIP(r)
+	targetUser, err := h.store.GetUser(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get user")
+		return
+	}
+	if targetUser == nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	targetName := targetUser.Name
+
 	existingHash, err := h.store.GetUserPinHash(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to check pin")
 		return
 	}
-	if existingHash == "" {
-		// No PIN set yet — ensure the target user actually exists.
-		u, err := h.store.GetUser(r.Context(), id)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to get user")
-			return
-		}
-		if u == nil {
-			writeError(w, http.StatusNotFound, "user not found")
-			return
-		}
-	} else if !adminOverride {
+	if existingHash != "" && !adminOverride {
 		// Caller is changing their own PIN — must supply the current value.
 		if err := bcrypt.CompareHashAndPassword([]byte(existingHash), []byte(req.CurrentPin)); err != nil {
+			log.Printf("auth: failed pin change attempt for user %d (%s) by user %d (%s) from %s", id, targetName, caller.ID, caller.Name, ip)
+			if h.dispatcher != nil {
+				h.dispatcher.Fire(webhook.EventProfilePinFailed, map[string]any{
+					"user_id":    id,
+					"user_name":  targetName,
+					"actor_id":   caller.ID,
+					"actor_name": caller.Name,
+					"ip_address": ip,
+				})
+			}
 			writeError(w, http.StatusUnauthorized, "incorrect current pin")
 			return
 		}
@@ -480,6 +520,20 @@ func (h *UserHandler) SetPin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to save pin")
 		return
 	}
+
+	log.Printf("auth: user %d (%s) pin set by user %d (%s) from %s (admin_override=%v)", id, targetName, caller.ID, caller.Name, ip, adminOverride)
+	if h.dispatcher != nil {
+		h.dispatcher.Fire(webhook.EventProfilePinChanged, map[string]any{
+			"user_id":        id,
+			"user_name":      targetName,
+			"actor_id":       caller.ID,
+			"actor_name":     caller.Name,
+			"admin_override": adminOverride,
+			"is_new":         existingHash == "",
+			"ip_address":     ip,
+		})
+	}
+
 	writeJSON(w, http.StatusOK, map[string]bool{"has_pin": true})
 }
 
@@ -511,6 +565,18 @@ func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 	}
 	adminOverride := isAdmin && !targetIsSelf
 
+	ip := clientIP(r)
+	targetUser, err := h.store.GetUser(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get user")
+		return
+	}
+	if targetUser == nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	targetName := targetUser.Name
+
 	existingHash, err := h.store.GetUserPinHash(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to check pin")
@@ -529,6 +595,16 @@ func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := bcrypt.CompareHashAndPassword([]byte(existingHash), []byte(req.CurrentPin)); err != nil {
+			log.Printf("auth: failed pin clear attempt for user %d (%s) by user %d (%s) from %s", id, targetName, caller.ID, caller.Name, ip)
+			if h.dispatcher != nil {
+				h.dispatcher.Fire(webhook.EventProfilePinFailed, map[string]any{
+					"user_id":    id,
+					"user_name":  targetName,
+					"actor_id":   caller.ID,
+					"actor_name": caller.Name,
+					"ip_address": ip,
+				})
+			}
 			writeError(w, http.StatusUnauthorized, "incorrect current pin")
 			return
 		}
@@ -538,6 +614,19 @@ func (h *UserHandler) ClearPin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to clear pin")
 		return
 	}
+
+	log.Printf("auth: user %d (%s) pin cleared by user %d (%s) from %s (admin_override=%v)", id, targetName, caller.ID, caller.Name, ip, adminOverride)
+	if h.dispatcher != nil {
+		h.dispatcher.Fire(webhook.EventProfilePinCleared, map[string]any{
+			"user_id":        id,
+			"user_name":      targetName,
+			"actor_id":       caller.ID,
+			"actor_name":     caller.Name,
+			"admin_override": adminOverride,
+			"ip_address":     ip,
+		})
+	}
+
 	writeJSON(w, http.StatusOK, map[string]bool{"has_pin": false})
 }
 

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -19,15 +19,22 @@ import (
 
 // Event types
 const (
-	EventChoreCompleted   = "chore.completed"
-	EventChoreUncompleted = "chore.uncompleted"
-	EventChoreExpired     = "chore.expired"
-	EventRewardRedeemed   = "reward.redeemed"
-	EventDailyComplete    = "daily.complete"
-	EventStreakMilestone   = "streak.milestone"
-	EventPointsDecayed       = "points.decayed"
-	EventChoreMissed         = "chore.missed"
-	EventChoreFCFSCompleted  = "chore.fcfs_completed"
+	EventChoreCompleted        = "chore.completed"
+	EventChoreUncompleted      = "chore.uncompleted"
+	EventChoreExpired          = "chore.expired"
+	EventRewardRedeemed        = "reward.redeemed"
+	EventDailyComplete         = "daily.complete"
+	EventStreakMilestone       = "streak.milestone"
+	EventPointsDecayed         = "points.decayed"
+	EventChoreMissed           = "chore.missed"
+	EventChoreFCFSCompleted    = "chore.fcfs_completed"
+	EventAdminPasscodeVerified = "auth.admin_passcode.verified"
+	EventAdminPasscodeFailed   = "auth.admin_passcode.failed"
+	EventAdminPasscodeChanged  = "auth.admin_passcode.changed"
+	EventProfilePinVerified    = "auth.profile_pin.verified"
+	EventProfilePinFailed      = "auth.profile_pin.failed"
+	EventProfilePinChanged     = "auth.profile_pin.changed"
+	EventProfilePinCleared     = "auth.profile_pin.cleared"
 )
 
 type Dispatcher struct {

--- a/web/src/components/admin/SettingsTab.tsx
+++ b/web/src/components/admin/SettingsTab.tsx
@@ -48,6 +48,13 @@ export const SettingsTab: React.FC = () => {
     { id: 'daily.complete', label: t('admin.settingsTab.webhooks.events.dailyDone'), icon: '🌟' },
     { id: 'streak.milestone', label: t('admin.settingsTab.webhooks.events.streak'), icon: '🔥' },
     { id: 'points.decayed', label: t('admin.settingsTab.webhooks.events.decay'), icon: '📉' },
+    { id: 'auth.admin_passcode.verified', label: t('admin.settingsTab.webhooks.events.adminPasscodeVerified'), icon: '🔑' },
+    { id: 'auth.admin_passcode.failed', label: t('admin.settingsTab.webhooks.events.adminPasscodeFailed'), icon: '🚫' },
+    { id: 'auth.admin_passcode.changed', label: t('admin.settingsTab.webhooks.events.adminPasscodeChanged'), icon: '🔄' },
+    { id: 'auth.profile_pin.verified', label: t('admin.settingsTab.webhooks.events.profilePinVerified'), icon: '🔓' },
+    { id: 'auth.profile_pin.failed', label: t('admin.settingsTab.webhooks.events.profilePinFailed'), icon: '⚠️' },
+    { id: 'auth.profile_pin.changed', label: t('admin.settingsTab.webhooks.events.profilePinChanged'), icon: '🔢' },
+    { id: 'auth.profile_pin.cleared', label: t('admin.settingsTab.webhooks.events.profilePinCleared'), icon: '🗑️' },
   ];
 
   const allEventsSelected = webhookSelectedEvents.size === 0 || webhookSelectedEvents.size === WEBHOOK_EVENTS.length;

--- a/web/src/i18n/locales/de/translation.json
+++ b/web/src/i18n/locales/de/translation.json
@@ -460,11 +460,18 @@
         "empty": "Keine Webhooks konfiguriert",
         "enableButton": "Aktivieren",
         "events": {
+          "adminPasscodeChanged": "Admin-Passcode geändert",
+          "adminPasscodeFailed": "Admin-Passcode fehlgeschlagen",
+          "adminPasscodeVerified": "Admin-Passcode verifiziert",
           "completed": "Abgeschlossen",
           "dailyDone": "Tagesaufgaben geschafft!",
           "decay": "Verfallen",
           "expired": "Abgelaufen",
           "missed": "Verpasst",
+          "profilePinChanged": "Profil-PIN geändert",
+          "profilePinCleared": "Profil-PIN gelöscht",
+          "profilePinFailed": "Profil-PIN fehlgeschlagen",
+          "profilePinVerified": "Profil-PIN verifiziert",
           "redeemed": "Eingelöst",
           "streak": "Streak",
           "uncompleted": "Zurückgesetzt"

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -460,11 +460,18 @@
         "empty": "No webhooks configured",
         "enableButton": "Enable",
         "events": {
+          "adminPasscodeChanged": "Admin Passcode Changed",
+          "adminPasscodeFailed": "Admin Passcode Failed",
+          "adminPasscodeVerified": "Admin Passcode Verified",
           "completed": "Completed",
           "dailyDone": "Daily Done",
           "decay": "Decay",
           "expired": "Expired",
           "missed": "Missed",
+          "profilePinChanged": "Profile PIN Changed",
+          "profilePinCleared": "Profile PIN Cleared",
+          "profilePinFailed": "Profile PIN Failed",
+          "profilePinVerified": "Profile PIN Verified",
           "redeemed": "Redeemed",
           "streak": "Streak",
           "uncompleted": "Uncompleted"


### PR DESCRIPTION
Closes #48

### Summary

Logs and dispatches webhook events for all PIN- and passcode-related operations across both the Admin Passcode and User Profile PIN authentication surfaces:
- **Admin Passcode**:
  - Verification succeeded (`auth.admin_passcode.verified`) / failed (`auth.admin_passcode.failed`)
  - Passcode updated (`auth.admin_passcode.changed`) / update failed (`auth.admin_passcode.failed`)
- **User Profile PIN**:
  - Verification succeeded (`auth.profile_pin.verified`) / failed (`auth.profile_pin.failed`)
  - PIN set or changed (`auth.profile_pin.changed`)
  - PIN cleared / reset (`auth.profile_pin.cleared`)

### Security
- **Zero Plaintext PIN Exposure**: Raw submitted PIN and passcode values are never included in server log output, webhook event payloads, or error responses.
- Client IP addresses and User-Agents are safely extracted and recorded in metadata.

### Changes
- `internal/webhook/dispatcher.go`: Added `auth.admin_passcode.*` and `auth.profile_pin.*` event constants.
- `internal/api/helpers.go`: Added `clientIP` helper to safely extract client IP from proxy headers or remote address.
- `internal/api/admin.go`: Injected `dispatcher` and added server logging and webhook event emission on passcode verification and update.
- `internal/api/users.go`: Injected `dispatcher` and added server logging and webhook event emission on profile PIN verification, set, and clear.
- `internal/api/router.go`: Passed webhook dispatcher to `NewAdminHandler` and `NewUserHandler`.
- `web/src/components/admin/SettingsTab.tsx`: Added the new auth events to the Webhooks event selector.
- `web/src/i18n/locales/{en,de}/translation.json`: Added localized event labels.
- `internal/api/api_test.go`: Added comprehensive test suites verifying webhook event dispatches, metadata structure, and absence of plaintext PIN leaks.