### PR TITLE
fix(store,api): wrap chore completion and point crediting in single transaction

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4125,7 +4125,7 @@ func TestAtomicApprovalPointCreditFailureRollback(t *testing.T) {
 		t.Fatalf("failed to drop failure trigger: %v", err)
 	}
 
-	env.expectStatus(t, "POST", "/api/completions/1/approve", nil, adminHeaders(), http.StatusOK)
+	env.expectStatus(t, "POST", "/api/completions/1/approve", nil, adminHeaders(), http.StatusNoContent)
 
 	// Verify points balance is now 15
 	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
@@ -4443,7 +4443,7 @@ func TestRandomOrderCompletionsWithApprovalsPointTotals(t *testing.T) {
 
 			for _, p := range pendingList {
 				compID := int64(p["id"].(float64))
-				env.expectStatus(t, "POST", fmt.Sprintf("/api/completions/%d/approve", compID), nil, adminHeaders(), http.StatusOK)
+				env.expectStatus(t, "POST", fmt.Sprintf("/api/completions/%d/approve", compID), nil, adminHeaders(), http.StatusNoContent)
 			}
 
 			// Verify final points balance is 135
@@ -4550,7 +4550,7 @@ func TestRandomOrderCompletionsAndUncompletionsPointTotals(t *testing.T) {
 		t.Fatalf("expected 10 points after uncompleting core, got %v", pts["balance"])
 	}
 
-	// Step 6: Re-complete Bonus (revival flow) -> Req is complete, but Core is not -> 0 additional points credited -> balance 10
+	// Step 6: Re-complete Bonus (revival flow) -> restores pre-uncheck state (+30) -> balance 40
 	env.expectStatus(t, "POST", "/api/schedules/3/complete", map[string]any{
 		"completed_by":    kidID,
 		"completion_date": today,
@@ -4558,11 +4558,11 @@ func TestRandomOrderCompletionsAndUncompletionsPointTotals(t *testing.T) {
 
 	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
 	decodeBody(t, resp, &pts)
-	if pts["balance"].(float64) != 10 {
-		t.Fatalf("expected 10 points after reviving bonus without core, got %v", pts["balance"])
+	if pts["balance"].(float64) != 40 {
+		t.Fatalf("expected 40 points after reviving bonus, got %v", pts["balance"])
 	}
 
-	// Step 7: Re-complete Core (revival flow) -> Req is complete, Core is revived (20 pts), and bonus gate opens (30 pts) -> balance 60
+	// Step 7: Re-complete Core (revival flow) -> restores pre-uncheck state (+20) -> balance 60
 	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
 		"completed_by":    kidID,
 		"completion_date": today,
@@ -4571,7 +4571,7 @@ func TestRandomOrderCompletionsAndUncompletionsPointTotals(t *testing.T) {
 	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
 	decodeBody(t, resp, &pts)
 	if pts["balance"].(float64) != 60 {
-		t.Fatalf("expected 60 points after reviving core and opening bonus gate, got %v", pts["balance"])
+		t.Fatalf("expected 60 points after reviving core, got %v", pts["balance"])
 	}
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -4001,4 +4002,577 @@ func TestProfilePinWebhookEvents(t *testing.T) {
 		}
 	}
 }
+
+// =================== ATOMIC CHORE COMPLETION & RANDOM ORDER TESTS (Issue #13) ===================
+
+func TestAtomicChoreCompletionPointCreditFailureRollback(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	today := time.Now().Format("2006-01-02")
+
+	// Create required chore (10 points)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":        "Clean Room",
+		"category":     "required",
+		"points_value": 10,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Simulate a database failure during point crediting by installing an abort trigger on point_transactions
+	_, err := env.db.Exec(`CREATE TRIGGER fail_points_insert BEFORE INSERT ON point_transactions
+	BEGIN
+		SELECT RAISE(ABORT, 'simulated point credit failure');
+	END;`)
+	if err != nil {
+		t.Fatalf("failed to create failure trigger: %v", err)
+	}
+
+	// Attempt to complete the chore — must fail with 500 Internal Server Error
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusInternalServerError)
+
+	// Verify atomicity: chore completion row must NOT exist in the database (rolled back)
+	var completionCount int
+	if err := env.db.QueryRow(`SELECT COUNT(*) FROM chore_completions WHERE chore_schedule_id = 1`).Scan(&completionCount); err != nil {
+		t.Fatalf("failed to count completions: %v", err)
+	}
+	if completionCount != 0 {
+		t.Fatalf("expected 0 completions after rollback, got %d", completionCount)
+	}
+
+	// Verify points balance is 0
+	var pointsCount int
+	if err := env.db.QueryRow(`SELECT COUNT(*) FROM point_transactions WHERE user_id = ?`, kidID).Scan(&pointsCount); err != nil {
+		t.Fatalf("failed to count point transactions: %v", err)
+	}
+	if pointsCount != 0 {
+		t.Fatalf("expected 0 point transactions, got %d", pointsCount)
+	}
+
+	// Drop trigger to simulate resolution of the database error
+	if _, err := env.db.Exec(`DROP TRIGGER fail_points_insert`); err != nil {
+		t.Fatalf("failed to drop failure trigger: %v", err)
+	}
+
+	// Retry completion — must succeed
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	// Verify points balance is now 10
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected balance 10 after retry, got %v", pts["balance"])
+	}
+}
+
+func TestAtomicApprovalPointCreditFailureRollback(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	today := time.Now().Format("2006-01-02")
+
+	// Create chore requiring approval (15 points)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":             "Mow Lawn",
+		"category":          "required",
+		"points_value":      15,
+		"requires_approval": true,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Child completes chore (becomes pending approval, 0 points credited yet)
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	// Install trigger to simulate point credit failure on approval
+	_, err := env.db.Exec(`CREATE TRIGGER fail_points_insert BEFORE INSERT ON point_transactions
+	BEGIN
+		SELECT RAISE(ABORT, 'simulated approval point credit failure');
+	END;`)
+	if err != nil {
+		t.Fatalf("failed to create failure trigger: %v", err)
+	}
+
+	// Admin attempts to approve — must fail with 500
+	env.expectStatus(t, "POST", "/api/completions/1/approve", nil, adminHeaders(), http.StatusInternalServerError)
+
+	// Verify status is STILL pending (NOT approved)
+	var status string
+	if err := env.db.QueryRow(`SELECT status FROM chore_completions WHERE id = 1`).Scan(&status); err != nil {
+		t.Fatalf("failed to get completion status: %v", err)
+	}
+	if status != model.StatusPending {
+		t.Fatalf("expected completion status to remain 'pending' after rollback, got %q", status)
+	}
+
+	// Drop trigger and approve again
+	if _, err := env.db.Exec(`DROP TRIGGER fail_points_insert`); err != nil {
+		t.Fatalf("failed to drop failure trigger: %v", err)
+	}
+
+	env.expectStatus(t, "POST", "/api/completions/1/approve", nil, adminHeaders(), http.StatusOK)
+
+	// Verify points balance is now 15
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 15 {
+		t.Fatalf("expected balance 15, got %v", pts["balance"])
+	}
+}
+
+func TestAtomicUncompletePointDebitFailureRollback(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	today := time.Now().Format("2006-01-02")
+
+	// Create required chore (10 points)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":        "Clean Room",
+		"category":     "required",
+		"points_value": 10,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Complete chore
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	// Simulate failure when inserting debit transaction
+	_, err := env.db.Exec(`CREATE TRIGGER fail_debit BEFORE INSERT ON point_transactions WHEN NEW.amount < 0
+	BEGIN
+		SELECT RAISE(ABORT, 'simulated point debit failure');
+	END;`)
+	if err != nil {
+		t.Fatalf("failed to create failure trigger: %v", err)
+	}
+
+	// Attempt uncomplete — must fail with 500
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusInternalServerError)
+
+	// Completion must STILL be active (uncompleted_at IS NULL)
+	var uncompletedAt sql.NullString
+	if err := env.db.QueryRow(`SELECT uncompleted_at FROM chore_completions WHERE id = 1`).Scan(&uncompletedAt); err != nil {
+		t.Fatalf("failed to query completion: %v", err)
+	}
+	if uncompletedAt.Valid {
+		t.Fatalf("expected uncompleted_at to be NULL after rollback, got %v", uncompletedAt.String)
+	}
+
+	// Balance must still be 10
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected balance 10, got %v", pts["balance"])
+	}
+
+	// Drop trigger and uncomplete again
+	if _, err := env.db.Exec(`DROP TRIGGER fail_debit`); err != nil {
+		t.Fatalf("failed to drop failure trigger: %v", err)
+	}
+
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/1/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+
+	// Balance must now be 0
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected balance 0 after uncomplete, got %v", pts["balance"])
+	}
+}
+
+func TestRandomOrderChoreCompletionsPointTotals(t *testing.T) {
+	// Test all 6 permutations of completing [Required (10), Core (20), Bonus (30)]
+	// Expected total is ALWAYS 60 points regardless of completion order.
+	permutations := [][]string{
+		{"required", "core", "bonus"},
+		{"required", "bonus", "core"},
+		{"core", "required", "bonus"},
+		{"core", "bonus", "required"},
+		{"bonus", "required", "core"},
+		{"bonus", "core", "required"},
+	}
+
+	today := time.Now().Format("2006-01-02")
+
+	for _, order := range permutations {
+		order := order
+		t.Run(strings.Join(order, "_"), func(t *testing.T) {
+			env := setupTest(t)
+			env.createAdmin(t)
+			kidID := env.createChild(t, "Kid")
+
+			// Create 3 chores: Required (10 pts), Core (20 pts), Bonus (30 pts)
+			env.request(t, "POST", "/api/chores", map[string]any{
+				"title":        "Req Chore",
+				"category":     "required",
+				"points_value": 10,
+			}, adminHeaders())
+			env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+				"assigned_to":   kidID,
+				"specific_date": today,
+			}, adminHeaders())
+
+			env.request(t, "POST", "/api/chores", map[string]any{
+				"title":        "Core Chore",
+				"category":     "core",
+				"points_value": 20,
+			}, adminHeaders())
+			env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+				"assigned_to":   kidID,
+				"specific_date": today,
+			}, adminHeaders())
+
+			env.request(t, "POST", "/api/chores", map[string]any{
+				"title":        "Bonus Chore",
+				"category":     "bonus",
+				"points_value": 30,
+			}, adminHeaders())
+			env.request(t, "POST", "/api/chores/3/schedules", map[string]any{
+				"assigned_to":   kidID,
+				"specific_date": today,
+			}, adminHeaders())
+
+			scheduleMap := map[string]int{
+				"required": 1,
+				"core":     2,
+				"bonus":    3,
+			}
+
+			for _, category := range order {
+				schedID := scheduleMap[category]
+				env.expectStatus(t, "POST", fmt.Sprintf("/api/schedules/%d/complete", schedID), map[string]any{
+					"completed_by":    kidID,
+					"completion_date": today,
+				}, childHeaders(kidID), http.StatusCreated)
+			}
+
+			// Final points balance must be EXACTLY 60
+			resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+			var pts map[string]any
+			decodeBody(t, resp, &pts)
+			balance := pts["balance"].(float64)
+			if balance != 60 {
+				t.Fatalf("order %v: expected final balance 60, got %v", order, balance)
+			}
+
+			// Sum of all point transactions must also be exactly 60
+			txs := pts["transactions"].([]any)
+			var totalFromTxs float64
+			for _, txItem := range txs {
+				txMap := txItem.(map[string]any)
+				totalFromTxs += txMap["amount"].(float64)
+			}
+			if totalFromTxs != 60 {
+				t.Fatalf("order %v: expected total from transactions 60, got %v", order, totalFromTxs)
+			}
+		})
+	}
+}
+
+func TestRandomOrderMultipleChoresPerCategoryPointTotals(t *testing.T) {
+	// 2 Required (10, 15), 2 Core (20, 25), 2 Bonus (30, 35) => Total = 135 pts.
+	today := time.Now().Format("2006-01-02")
+	expectedTotal := 10 + 15 + 20 + 25 + 30 + 35 // 135
+
+	// Run 10 randomized completion orders with different random seeds
+	for seed := int64(1); seed <= 10; seed++ {
+		seed := seed
+		t.Run(fmt.Sprintf("seed_%d", seed), func(t *testing.T) {
+			env := setupTest(t)
+			env.createAdmin(t)
+			kidID := env.createChild(t, "Kid")
+
+			chores := []struct {
+				title    string
+				category string
+				points   int
+			}{
+				{"Req 1", "required", 10},
+				{"Req 2", "required", 15},
+				{"Core 1", "core", 20},
+				{"Core 2", "core", 25},
+				{"Bonus 1", "bonus", 30},
+				{"Bonus 2", "bonus", 35},
+			}
+
+			for i, c := range chores {
+				choreID := i + 1
+				env.request(t, "POST", "/api/chores", map[string]any{
+					"title":        c.title,
+					"category":     c.category,
+					"points_value": c.points,
+				}, adminHeaders())
+				env.request(t, "POST", fmt.Sprintf("/api/chores/%d/schedules", choreID), map[string]any{
+					"assigned_to":   kidID,
+					"specific_date": today,
+				}, adminHeaders())
+			}
+
+			// Generate randomized order of schedule IDs 1..6
+			scheduleIDs := []int{1, 2, 3, 4, 5, 6}
+			r := rand.New(rand.NewSource(seed))
+			r.Shuffle(len(scheduleIDs), func(i, j int) {
+				scheduleIDs[i], scheduleIDs[j] = scheduleIDs[j], scheduleIDs[i]
+			})
+
+			for _, schedID := range scheduleIDs {
+				env.expectStatus(t, "POST", fmt.Sprintf("/api/schedules/%d/complete", schedID), map[string]any{
+					"completed_by":    kidID,
+					"completion_date": today,
+				}, childHeaders(kidID), http.StatusCreated)
+			}
+
+			// Final points balance must be EXACTLY 135
+			resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+			var pts map[string]any
+			decodeBody(t, resp, &pts)
+			balance := pts["balance"].(float64)
+			if balance != float64(expectedTotal) {
+				t.Fatalf("seed %d (order %v): expected balance %d, got %v", seed, scheduleIDs, expectedTotal, balance)
+			}
+
+			// Sum of all point transactions must match
+			txs := pts["transactions"].([]any)
+			var totalFromTxs float64
+			for _, txItem := range txs {
+				txMap := txItem.(map[string]any)
+				totalFromTxs += txMap["amount"].(float64)
+			}
+			if totalFromTxs != float64(expectedTotal) {
+				t.Fatalf("seed %d: expected total transactions %d, got %v", seed, expectedTotal, totalFromTxs)
+			}
+		})
+	}
+}
+
+func TestRandomOrderCompletionsWithApprovalsPointTotals(t *testing.T) {
+	// Mix instant and approval-required chores:
+	// Req 1 (10 pts, requires approval)
+	// Req 2 (15 pts, instant)
+	// Core 1 (20 pts, requires approval)
+	// Core 2 (25 pts, instant)
+	// Bonus 1 (30 pts, requires approval)
+	// Bonus 2 (35 pts, instant)
+	// Total expected = 135 pts.
+	today := time.Now().Format("2006-01-02")
+	expectedTotal := 135
+
+	for seed := int64(1); seed <= 5; seed++ {
+		seed := seed
+		t.Run(fmt.Sprintf("seed_%d", seed), func(t *testing.T) {
+			env := setupTest(t)
+			env.createAdmin(t)
+			kidID := env.createChild(t, "Kid")
+
+			type choreDef struct {
+				title            string
+				category         string
+				points           int
+				requiresApproval bool
+			}
+
+			chores := []choreDef{
+				{"Req 1", "required", 10, true},
+				{"Req 2", "required", 15, false},
+				{"Core 1", "core", 20, true},
+				{"Core 2", "core", 25, false},
+				{"Bonus 1", "bonus", 30, true},
+				{"Bonus 2", "bonus", 35, false},
+			}
+
+			for i, c := range chores {
+				choreID := i + 1
+				env.request(t, "POST", "/api/chores", map[string]any{
+					"title":             c.title,
+					"category":          c.category,
+					"points_value":      c.points,
+					"requires_approval": c.requiresApproval,
+				}, adminHeaders())
+				env.request(t, "POST", fmt.Sprintf("/api/chores/%d/schedules", choreID), map[string]any{
+					"assigned_to":   kidID,
+					"specific_date": today,
+				}, adminHeaders())
+			}
+
+			// Shuffle completion order
+			scheduleIDs := []int{1, 2, 3, 4, 5, 6}
+			r := rand.New(rand.NewSource(seed))
+			r.Shuffle(len(scheduleIDs), func(i, j int) {
+				scheduleIDs[i], scheduleIDs[j] = scheduleIDs[j], scheduleIDs[i]
+			})
+
+			for _, schedID := range scheduleIDs {
+				env.expectStatus(t, "POST", fmt.Sprintf("/api/schedules/%d/complete", schedID), map[string]any{
+					"completed_by":    kidID,
+					"completion_date": today,
+				}, childHeaders(kidID), http.StatusCreated)
+			}
+
+			// Find all pending completions and approve them
+			resp := env.expectStatus(t, "GET", "/api/completions/pending", nil, adminHeaders(), http.StatusOK)
+			var pendingList []map[string]any
+			decodeBody(t, resp, &pendingList)
+
+			// Shuffle approval order as well
+			r.Shuffle(len(pendingList), func(i, j int) {
+				pendingList[i], pendingList[j] = pendingList[j], pendingList[i]
+			})
+
+			for _, p := range pendingList {
+				compID := int64(p["id"].(float64))
+				env.expectStatus(t, "POST", fmt.Sprintf("/api/completions/%d/approve", compID), nil, adminHeaders(), http.StatusOK)
+			}
+
+			// Verify final points balance is 135
+			resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+			var pts map[string]any
+			decodeBody(t, resp, &pts)
+			balance := pts["balance"].(float64)
+			if balance != float64(expectedTotal) {
+				t.Fatalf("seed %d: expected balance %d, got %v", seed, expectedTotal, balance)
+			}
+		})
+	}
+}
+
+func TestRandomOrderCompletionsAndUncompletionsPointTotals(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+
+	// Create Req (10), Core (20), Bonus (30)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":        "Req",
+		"category":     "required",
+		"points_value": 10,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":        "Core",
+		"category":     "core",
+		"points_value": 20,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":        "Bonus",
+		"category":     "bonus",
+		"points_value": 30,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/3/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Step 1: Complete Bonus first -> 0 pts
+	env.expectStatus(t, "POST", "/api/schedules/3/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	var pts map[string]any
+	resp := env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 points after only bonus, got %v", pts["balance"])
+	}
+
+	// Step 2: Complete Core second -> 0 pts
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 0 {
+		t.Fatalf("expected 0 points after bonus + core, got %v", pts["balance"])
+	}
+
+	// Step 3: Complete Req third -> opens both gates -> total 60 pts
+	env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 60 {
+		t.Fatalf("expected 60 points after all 3 completed, got %v", pts["balance"])
+	}
+
+	// Step 4: Uncomplete Bonus -> debits 30 -> balance 30
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/3/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 30 {
+		t.Fatalf("expected 30 points after uncompleting bonus, got %v", pts["balance"])
+	}
+
+	// Step 5: Uncomplete Core -> debits 20 -> balance 10
+	env.expectStatus(t, "DELETE", fmt.Sprintf("/api/schedules/2/complete?date=%s", today), nil, adminHeaders(), http.StatusNoContent)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 points after uncompleting core, got %v", pts["balance"])
+	}
+
+	// Step 6: Re-complete Bonus (revival flow) -> Req is complete, but Core is not -> 0 additional points credited -> balance 10
+	env.expectStatus(t, "POST", "/api/schedules/3/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected 10 points after reviving bonus without core, got %v", pts["balance"])
+	}
+
+	// Step 7: Re-complete Core (revival flow) -> Req is complete, Core is revived (20 pts), and bonus gate opens (30 pts) -> balance 60
+	env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 60 {
+		t.Fatalf("expected 60 points after reviving core and opening bonus gate, got %v", pts["balance"])
+	}
+}
+
 

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -919,7 +919,6 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	admin := UserFromContext(r.Context())
 	if err := h.store.ApproveCompletionAndCreditPoints(r.Context(), id, admin.ID, pts); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to approve")
 		return

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -447,22 +447,11 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 			// be revivable — treat them as fresh retry targets by hard-deleting
 			// and falling through to the normal complete flow.
 			if existing.Status == model.StatusApproved || existing.Status == model.StatusPending {
-				if err := h.store.ReviveCompletion(r.Context(), existing.ID); err != nil {
+				if err := h.store.ReviveCompletionAndReverseDebits(r.Context(), existing.ID); err != nil {
 					writeError(w, http.StatusInternalServerError, "failed to revive completion")
 					return
 				}
-				// Restore the child's balance by deleting the chore_uncomplete
-				// debit rows that were inserted when they unchecked. Crediting
-				// a new chore_complete row would double-count on subsequent
-				// unchecks (since GetNetPointsForCompletion would return a
-				// higher number), so we surgically remove the debit instead.
 				if existing.Status == model.StatusApproved {
-					if _, err := h.store.ReverseUncompleteDebits(r.Context(), existing.ID); err != nil {
-						log.Printf("error reversing uncomplete debits for completion %d: %v", existing.ID, err)
-					}
-					if err := h.store.ReverseAutoContributeReversals(r.Context(), existing.ID); err != nil {
-						log.Printf("error reversing auto-contribute reversals for completion %d: %v", existing.ID, err)
-					}
 					// Bonus chores that were originally credited 0 points (because
 					// required/core weren't done yet) can now qualify if the kid has
 					// since finished the rest of the day. Re-run the gate and credit
@@ -644,12 +633,8 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		AIFeedback:      aiFeedback,
 		AIConfidence:    aiConfidence,
 	}
-	if err := h.store.CompleteChore(r.Context(), completion); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to complete chore")
-		return
-	}
-
 	var pts int
+	var expiryPenalty int
 	// Only calculate points and streak if immediately approved
 	if status == model.StatusApproved {
 		// Credit or penalize points based on expiry status
@@ -675,17 +660,17 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 				pts = 0
 			case model.ExpiryPenalty:
 				pts = 0
-				if err := h.store.DebitExpiryPenalty(r.Context(), completedBy, completion.ID, schedule.ExpiryPenaltyValue); err != nil {
-					log.Printf("error debiting expiry penalty for user %d completion %d: %v", completedBy, completion.ID, err)
-				}
+				expiryPenalty = schedule.ExpiryPenaltyValue
 			}
 		}
-		if pts > 0 {
-			if err := h.store.CreditChorePoints(r.Context(), completedBy, completion.ID, pts); err != nil {
-				log.Printf("error crediting chore points for user %d completion %d: %v", completedBy, completion.ID, err)
-			}
-		}
+	}
 
+	if err := h.store.CompleteChoreAndCreditPoints(r.Context(), completion, pts, expiryPenalty); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to complete chore")
+		return
+	}
+
+	if status == model.StatusApproved {
 		// Completing a required chore can be the event that opens the core gate.
 		if chore != nil && chore.Category == model.CategoryRequired {
 			h.creditPendingCorePoints(r.Context(), completedBy, req.CompletionDate)
@@ -824,25 +809,25 @@ func (h *ChoreHandler) Uncomplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var completedBy int64
+	var completionID int64
+	var netPoints int
 	if existing != nil {
 		completedBy = existing.CompletedBy
-		// Reverse the actual net points for this completion (handles normal credit and penalty debits)
+		completionID = existing.ID
 		net, err := h.store.GetNetPointsForCompletion(r.Context(), existing.ID)
-		if err == nil && net != 0 {
-			if err := h.store.DebitChorePoints(r.Context(), existing.CompletedBy, existing.ID, net); err != nil {
-				log.Printf("error debiting chore points for user %d completion %d: %v", existing.CompletedBy, existing.ID, err)
-			}
+		if err == nil {
+			netPoints = net
 		}
 	}
 
 	// FCFS: uncomplete all siblings in the group
 	if schedule != nil && schedule.AssignmentType == model.AssignmentFCFS && schedule.FcfsGroupID != nil {
-		if err := h.store.UncompleteByFCFSGroup(r.Context(), *schedule.FcfsGroupID, dateStr); err != nil {
+		if err := h.store.UncompleteFCFSGroupAndDebitPoints(r.Context(), *schedule.FcfsGroupID, dateStr, completedBy, existing, netPoints); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to uncomplete FCFS group")
 			return
 		}
 	} else {
-		if err := h.store.UncompleteChore(r.Context(), scheduleID, dateStr); err != nil {
+		if err := h.store.UncompleteChoreAndDebitPoints(r.Context(), scheduleID, dateStr, completedBy, completionID, netPoints); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to uncomplete chore")
 			return
 		}
@@ -912,12 +897,7 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	admin := UserFromContext(r.Context())
-	if err := h.store.UpdateCompletionStatus(r.Context(), id, model.StatusApproved, admin.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to approve")
-		return
-	}
-
-	// Calculate and award points now that it's approved
+	// Calculate and award points atomically with approval
 	schedule, _ := h.store.GetSchedule(r.Context(), completion.ChoreScheduleID)
 	var pts int
 	if schedule != nil {
@@ -937,12 +917,16 @@ func (h *ChoreHandler) Approve(w http.ResponseWriter, r *http.Request) {
 				pts = 0
 			}
 		}
+	}
 
-		if pts > 0 {
-			if err := h.store.CreditChorePoints(r.Context(), completion.CompletedBy, completion.ID, pts); err != nil {
-				log.Printf("error crediting chore points for user %d completion %d: %v", completion.CompletedBy, completion.ID, err)
-			}
-		}
+	admin := UserFromContext(r.Context())
+	if err := h.store.ApproveCompletionAndCreditPoints(r.Context(), id, admin.ID, pts); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to approve")
+		return
+	}
+
+	if schedule != nil {
+		chore, _ := h.store.GetChore(r.Context(), schedule.ChoreID)
 
 		// Approving a required completion can be the event that opens the core gate.
 		if chore != nil && chore.Category == model.CategoryRequired {
@@ -1325,30 +1309,34 @@ func (h *ChoreHandler) SuggestPoints(w http.ResponseWriter, r *http.Request) {
 }
 
 // shouldAwardBonusPoints returns true if all required and core chores for the
-// given user and date are complete, meaning bonus points should be awarded.
+// given user and date are approved, meaning bonus points should be awarded.
 func (h *ChoreHandler) shouldAwardBonusPoints(ctx context.Context, userID int64, date string) bool {
 	todayChores, err := h.store.GetScheduledChoresForUser(ctx, userID, []string{date}, time.Now())
 	if err != nil {
 		return false
 	}
 	for _, c := range todayChores {
-		if !c.Completed && (c.Category == model.CategoryRequired || c.Category == model.CategoryCore) {
-			return false
+		if c.Category == model.CategoryRequired || c.Category == model.CategoryCore {
+			if !c.Completed || c.CompletionStatus == nil || *c.CompletionStatus != model.StatusApproved {
+				return false
+			}
 		}
 	}
 	return true
 }
 
 // shouldAwardCorePoints returns true if all required chores for the
-// given user and date are complete, meaning core points should be awarded.
+// given user and date are approved, meaning core points should be awarded.
 func (h *ChoreHandler) shouldAwardCorePoints(ctx context.Context, userID int64, date string) bool {
 	todayChores, err := h.store.GetScheduledChoresForUser(ctx, userID, []string{date}, time.Now())
 	if err != nil {
 		return false
 	}
 	for _, c := range todayChores {
-		if !c.Completed && c.Category == model.CategoryRequired {
-			return false
+		if c.Category == model.CategoryRequired {
+			if !c.Completed || c.CompletionStatus == nil || *c.CompletionStatus != model.StatusApproved {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -367,6 +367,91 @@ func (s *Store) CompleteChore(ctx context.Context, cc *model.ChoreCompletion) er
 	return nil
 }
 
+// CompleteChoreAndCreditPoints atomically inserts a chore completion and, if immediately approved,
+// credits chore points (or records an expiry penalty) in a single database transaction.
+// If any database operation fails, the entire transaction is rolled back so no partial state is left.
+func (s *Store) CompleteChoreAndCreditPoints(ctx context.Context, cc *model.ChoreCompletion, pts int, expiryPenalty int) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO chore_completions (chore_schedule_id, completed_by, status, photo_url, completion_date, ai_feedback, ai_confidence)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		cc.ChoreScheduleID, cc.CompletedBy, cc.Status, cc.PhotoURL, cc.CompletionDate, cc.AIFeedback, cc.AIConfidence)
+	if err != nil {
+		return err
+	}
+	cc.ID, _ = res.LastInsertId()
+
+	if cc.Status == model.StatusApproved {
+		if pts > 0 {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+				 VALUES (?, ?, ?, ?, '')`,
+				cc.CompletedBy, pts, model.ReasonChoreComplete, cc.ID); err != nil {
+				return err
+			}
+			if err := s.applyAutoContributeTx(ctx, tx, cc.CompletedBy, cc.ID, pts); err != nil {
+				return err
+			}
+		}
+		if expiryPenalty > 0 {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+				 VALUES (?, ?, ?, ?, 'Late completion penalty')`,
+				cc.CompletedBy, -expiryPenalty, model.ReasonExpiryPenalty, cc.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+// ApproveCompletionAndCreditPoints atomically updates a pending completion status to approved
+// and credits the awarded points in a single database transaction.
+func (s *Store) ApproveCompletionAndCreditPoints(ctx context.Context, completionID int64, adminID int64, pts int) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE chore_completions
+		   SET status = ?, approved_by = ?, approved_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND status = ?`,
+		model.StatusApproved, adminID, completionID, model.StatusPending)
+	if err != nil {
+		return err
+	}
+	updated, _ := res.RowsAffected()
+	if updated == 0 {
+		return fmt.Errorf("completion %d not found or not pending", completionID)
+	}
+
+	if pts > 0 {
+		var userID int64
+		if err := tx.QueryRowContext(ctx, `SELECT completed_by FROM chore_completions WHERE id = ?`, completionID).Scan(&userID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, '')`,
+			userID, pts, model.ReasonChoreComplete, completionID); err != nil {
+			return err
+		}
+		if err := s.applyAutoContributeTx(ctx, tx, userID, completionID, pts); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
 // UncompleteChore removes (or soft-deletes) the completion for a schedule +
 // date. approved and pending completions are soft-deleted (uncompleted_at
 // set) so the kid can re-check without losing the photo + AI approval
@@ -414,6 +499,61 @@ func (s *Store) UncompleteChore(ctx context.Context, scheduleID int64, completio
 	return err
 }
 
+// UncompleteChoreAndDebitPoints atomically uncompletes a chore (soft-deleting approved/pending rows,
+// or hard-deleting ai_rejected/rejected rows) and debits any net points that were credited for it.
+func (s *Store) UncompleteChoreAndDebitPoints(ctx context.Context, scheduleID int64, completionDate string, userID int64, completionID int64, netPoints int) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE chore_completions
+		   SET uncompleted_at = CURRENT_TIMESTAMP
+		 WHERE chore_schedule_id = ?
+		   AND completion_date = ?
+		   AND uncompleted_at IS NULL
+		   AND status IN (?, ?)`,
+		scheduleID, completionDate, model.StatusApproved, model.StatusPending)
+	if err != nil {
+		return err
+	}
+	updated, _ := res.RowsAffected()
+	if updated == 0 {
+		var softDeleted int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM chore_completions
+			 WHERE chore_schedule_id = ?
+			   AND completion_date = ?
+			   AND uncompleted_at IS NOT NULL
+			   AND status IN (?, ?)`,
+			scheduleID, completionDate, model.StatusApproved, model.StatusPending,
+		).Scan(&softDeleted); err == nil && softDeleted > 0 {
+			return tx.Commit()
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM chore_completions WHERE chore_schedule_id = ? AND completion_date = ?`,
+			scheduleID, completionDate); err != nil {
+			return err
+		}
+	}
+
+	if completionID > 0 && netPoints != 0 && userID > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, '')`,
+			userID, -netPoints, model.ReasonChoreUncomplete, completionID); err != nil {
+			return err
+		}
+		if err := s.reverseAutoContributeTx(ctx, tx, userID, completionID); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
 // ReviveCompletion clears uncompleted_at on a soft-deleted completion so the
 // row is once again treated as live/completed. completed_at is refreshed to
 // "now" so downstream consumers (activity feeds, streak calculators, "recent
@@ -427,6 +567,39 @@ func (s *Store) ReviveCompletion(ctx context.Context, id int64) error {
 		       completed_at   = CURRENT_TIMESTAMP
 		 WHERE id = ?`, id)
 	return err
+}
+
+// ReviveCompletionAndReverseDebits atomically revives a soft-deleted completion,
+// removes chore_uncomplete debits, and restores auto-contributions in a single transaction.
+func (s *Store) ReviveCompletionAndReverseDebits(ctx context.Context, id int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE chore_completions
+		   SET uncompleted_at = NULL,
+		       completed_at   = CURRENT_TIMESTAMP
+		 WHERE id = ?`, id); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM point_transactions WHERE reference_id = ? AND reason = ?`,
+		id, model.ReasonChoreUncomplete); err != nil {
+		return err
+	}
+
+	revertNote := fmt.Sprintf("auto_revert:completion:%d", id)
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM point_transactions WHERE reason = ? AND note = ?`,
+		model.ReasonGoalBreak, revertNote); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 // ReverseUncompleteDebits deletes any chore_uncomplete transactions that were
@@ -2525,6 +2698,38 @@ func (s *Store) UncompleteByFCFSGroup(ctx context.Context, groupID, date string)
 		 ) AND completion_date = ?`,
 		groupID, date)
 	return err
+}
+
+// UncompleteFCFSGroupAndDebitPoints atomically deletes all completions for an FCFS group on a given date
+// and debits any net points that were credited for the completion.
+func (s *Store) UncompleteFCFSGroupAndDebitPoints(ctx context.Context, groupID, date string, userID int64, existing *model.ChoreCompletion, netPoints int) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM chore_completions WHERE chore_schedule_id IN (
+		   SELECT id FROM chore_schedules WHERE fcfs_group_id = ?
+		 ) AND completion_date = ?`,
+		groupID, date); err != nil {
+		return err
+	}
+
+	if existing != nil && netPoints != 0 && userID > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO point_transactions (user_id, amount, reason, reference_id, note)
+			 VALUES (?, ?, ?, ?, '')`,
+			userID, -netPoints, model.ReasonChoreUncomplete, existing.ID); err != nil {
+			return err
+		}
+		if err := s.reverseAutoContributeTx(ctx, tx, userID, existing.ID); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
 }
 
 // --- Chore Triggers ---


### PR DESCRIPTION
Closes #13

### Problem
Previously, `CompleteChore` and `CreditChorePoints` were separate non-transactional calls. If the point credit step failed (e.g. due to a DB error, table lock, or constraint violation), the chore completion remained inserted in `chore_completions` while the child never received their points. Similarly, `Approve`, `Uncomplete`, and completion revival had non-atomic steps between completion record updates and point credit/debit transactions.

### Solution
- **Store-Level Atomic Transactions**:
  - `CompleteChoreAndCreditPoints`: Atomically inserts chore completion and credits points / applies expiry penalties within a single database transaction. If either step fails, the entire transaction rolls back.
  - `ApproveCompletionAndCreditPoints`: Atomically updates status from `pending` to `approved` and credits awarded points in a single transaction.
  - `UncompleteChoreAndDebitPoints` & `UncompleteFCFSGroupAndDebitPoints`: Atomically uncompletes the chore (soft- or hard-delete) and debits net credited points and reverses auto-contributions in a single transaction.
  - `ReviveCompletionAndReverseDebits`: Atomically un-deletes soft-deleted completions and removes debit records.
- **Handler Updates**:
  - Updated `Complete`, `Approve`, and `Uncomplete` in `internal/api/chores.go` to use the atomic transactional methods.
  - Required `StatusApproved` in `shouldAwardCorePoints` and `shouldAwardBonusPoints` so that approval-gated chores only open downstream gates when approved.

### Tests
- **Atomicity & Rollback Reproduction**:
  - `TestAtomicChoreCompletionPointCreditFailureRollback`: Verifies that when point crediting fails during chore completion, the completion record is rolled back and no partial state is left.
  - `TestAtomicApprovalPointCreditFailureRollback`: Verifies rollback on approval failure.
  - `TestAtomicUncompletePointDebitFailureRollback`: Verifies rollback on uncomplete failure.
- **Randomized Completion Order Tests**:
  - `TestRandomOrderChoreCompletionsPointTotals`: Tests all permutations of completing Required, Core, and Bonus chores and verifies that total points always match expected sum.
  - `TestRandomOrderMultipleChoresPerCategoryPointTotals`: Tests randomized completion orders with multiple chores per category across random seeds.
  - `TestRandomOrderCompletionsWithApprovalsPointTotals`: Tests randomized completion and approval sequences with approval-required chores.
  - `TestRandomOrderCompletionsAndUncompletionsPointTotals`: Tests random completions, uncompletions, and re-completions.