### PR TITLE
feat(chores): skip approval when parent/admin completes the chore

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4575,4 +4575,89 @@ func TestRandomOrderCompletionsAndUncompletionsPointTotals(t *testing.T) {
 	}
 }
 
+func TestAdminCompletingApprovalRequiredChoreSkipsPending(t *testing.T) {
+	env := setupTest(t)
+	env.createAdmin(t)
+	kidID := env.createChild(t, "Kid")
+	today := time.Now().Format("2006-01-02")
+
+	// Chore 1: requires_approval = true (10 pts)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":             "Chore 1",
+		"category":          "required",
+		"points_value":      10,
+		"requires_approval": true,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/1/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Admin completes Chore 1 on behalf of child -> should be immediately approved
+	resp := env.expectStatus(t, "POST", "/api/schedules/1/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, adminHeaders(), http.StatusCreated)
+
+	var comp map[string]any
+	decodeBody(t, resp, &comp)
+	if comp["status"] != model.StatusApproved {
+		t.Fatalf("expected status 'approved' when admin completes, got %q", comp["status"])
+	}
+
+	// Points should be immediately credited to kid
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	var pts map[string]any
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected balance 10, got %v", pts["balance"])
+	}
+
+	// Pending approvals list must be empty
+	resp = env.expectStatus(t, "GET", "/api/completions/pending", nil, adminHeaders(), http.StatusOK)
+	var pending []map[string]any
+	decodeBody(t, resp, &pending)
+	if len(pending) != 0 {
+		t.Fatalf("expected 0 pending completions, got %d", len(pending))
+	}
+
+	// Chore 2: requires_approval = true (15 pts)
+	env.request(t, "POST", "/api/chores", map[string]any{
+		"title":             "Chore 2",
+		"category":          "required",
+		"points_value":      15,
+		"requires_approval": true,
+	}, adminHeaders())
+	env.request(t, "POST", "/api/chores/2/schedules", map[string]any{
+		"assigned_to":   kidID,
+		"specific_date": today,
+	}, adminHeaders())
+
+	// Child completes Chore 2 -> should be pending approval
+	resp = env.expectStatus(t, "POST", "/api/schedules/2/complete", map[string]any{
+		"completed_by":    kidID,
+		"completion_date": today,
+	}, childHeaders(kidID), http.StatusCreated)
+
+	decodeBody(t, resp, &comp)
+	if comp["status"] != model.StatusPending {
+		t.Fatalf("expected status 'pending' when child completes, got %q", comp["status"])
+	}
+
+	// Balance should still be 10 (Chore 2 points not credited yet)
+	resp = env.expectStatus(t, "GET", fmt.Sprintf("/api/users/%d/points", kidID), nil, childHeaders(kidID), http.StatusOK)
+	decodeBody(t, resp, &pts)
+	if pts["balance"].(float64) != 10 {
+		t.Fatalf("expected balance 10, got %v", pts["balance"])
+	}
+
+	// Pending approvals list should have Chore 2
+	resp = env.expectStatus(t, "GET", "/api/completions/pending", nil, adminHeaders(), http.StatusOK)
+	decodeBody(t, resp, &pending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending completion, got %d", len(pending))
+	}
+}
+
+
 

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -432,6 +432,8 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	user := UserFromContext(r.Context())
+
 	// Check if already completed
 	existing, err := h.store.GetCompletionForScheduleDate(r.Context(), scheduleID, req.CompletionDate)
 	if err != nil {
@@ -620,7 +622,6 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	user := UserFromContext(r.Context())
 	completedBy := user.ID
 	if req.CompletedBy != 0 {
 		completedBy = req.CompletedBy

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -451,6 +451,13 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 					writeError(w, http.StatusInternalServerError, "failed to revive completion")
 					return
 				}
+				if user != nil && user.Role == "admin" && existing.Status == model.StatusPending {
+					existing.Status = model.StatusApproved
+					existing.ApprovedBy = &user.ID
+					now := time.Now()
+					existing.ApprovedAt = &now
+					_ = h.store.UpdateCompletionStatus(r.Context(), existing.ID, model.StatusApproved, user.ID)
+				}
 				if existing.Status == model.StatusApproved {
 					// Bonus chores that were originally credited 0 points (because
 					// required/core weren't done yet) can now qualify if the kid has
@@ -613,15 +620,23 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	status := model.StatusApproved
-	if chore != nil && chore.RequiresApproval {
-		status = model.StatusPending
-	}
-
 	user := UserFromContext(r.Context())
 	completedBy := user.ID
 	if req.CompletedBy != 0 {
 		completedBy = req.CompletedBy
+	}
+
+	status := model.StatusApproved
+	if chore != nil && chore.RequiresApproval && (user == nil || user.Role != "admin") {
+		status = model.StatusPending
+	}
+
+	var approvedBy *int64
+	var approvedAt *time.Time
+	if status == model.StatusApproved && user != nil && user.Role == "admin" {
+		approvedBy = &user.ID
+		now := time.Now()
+		approvedAt = &now
 	}
 
 	completion := &model.ChoreCompletion{
@@ -632,6 +647,8 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		CompletionDate:  req.CompletionDate,
 		AIFeedback:      aiFeedback,
 		AIConfidence:    aiConfidence,
+		ApprovedBy:      approvedBy,
+		ApprovedAt:      approvedAt,
 	}
 	var pts int
 	var expiryPenalty int

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -357,9 +357,9 @@ func (s *Store) GetScheduledChoresForUser(ctx context.Context, userID int64, dat
 
 func (s *Store) CompleteChore(ctx context.Context, cc *model.ChoreCompletion) error {
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO chore_completions (chore_schedule_id, completed_by, status, photo_url, completion_date, ai_feedback, ai_confidence)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		cc.ChoreScheduleID, cc.CompletedBy, cc.Status, cc.PhotoURL, cc.CompletionDate, cc.AIFeedback, cc.AIConfidence)
+		`INSERT INTO chore_completions (chore_schedule_id, completed_by, status, photo_url, completion_date, ai_feedback, ai_confidence, approved_by, approved_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cc.ChoreScheduleID, cc.CompletedBy, cc.Status, cc.PhotoURL, cc.CompletionDate, cc.AIFeedback, cc.AIConfidence, cc.ApprovedBy, cc.ApprovedAt)
 	if err != nil {
 		return err
 	}
@@ -378,9 +378,9 @@ func (s *Store) CompleteChoreAndCreditPoints(ctx context.Context, cc *model.Chor
 	defer tx.Rollback()
 
 	res, err := tx.ExecContext(ctx,
-		`INSERT INTO chore_completions (chore_schedule_id, completed_by, status, photo_url, completion_date, ai_feedback, ai_confidence)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		cc.ChoreScheduleID, cc.CompletedBy, cc.Status, cc.PhotoURL, cc.CompletionDate, cc.AIFeedback, cc.AIConfidence)
+		`INSERT INTO chore_completions (chore_schedule_id, completed_by, status, photo_url, completion_date, ai_feedback, ai_confidence, approved_by, approved_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cc.ChoreScheduleID, cc.CompletedBy, cc.Status, cc.PhotoURL, cc.CompletionDate, cc.AIFeedback, cc.AIConfidence, cc.ApprovedBy, cc.ApprovedAt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #46

### Summary
When a parent or admin completes a chore (either for themselves or on behalf of a child), the chore is immediately marked as `approved` (`model.StatusApproved`) with `approved_by` set to the admin's user ID, and points are awarded immediately rather than putting the completion into the `pending` approval queue.

When a child user completes an approval-required chore, it continues to require parent sign-off (`model.StatusPending`) as before.

### Changes
- `internal/api/chores.go`:
  - In `Complete`: If caller has `role == 'admin'`, bypass `StatusPending` and set status to `StatusApproved` with `ApprovedBy` and `ApprovedAt` recorded.
  - In `Revive`: If an admin revives a previously `StatusPending` completion, promote it directly to `StatusApproved`.
- `internal/store/store.go`:
  - In `CompleteChore` and `CompleteChoreAndCreditPoints`: persist `approved_by` and `approved_at` when provided on completion insert.
- `internal/api/api_test.go`:
  - Added `TestAdminCompletingApprovalRequiredChoreSkipsPending` asserting that admin completion skips pending queue and awards points immediately, while child completion goes to pending queue.