### PR TITLE
fix(e2e): make chore completion and approval tests time-independent

### DIFF
--- a/e2e/tests/approvals.spec.ts
+++ b/e2e/tests/approvals.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loginAsAdmin, apiGet } from './helpers/setup';
+import { loginAsAdmin, apiGet, localDateStr } from './helpers/setup';
 
 test.describe('Approval Workflow', () => {
   test('chore requiring approval goes to pending queue', async ({ page }) => {
@@ -24,7 +24,8 @@ test.describe('Approval Workflow', () => {
     });
 
     // Complete the chore as Natalie
-    const dateStr = today.toISOString().slice(0, 10);
+    // Local, not UTC: must match the weekday used for the schedule above.
+    const dateStr = localDateStr(today);
     const chores = await apiGet(page, `/users/3/chores?view=daily&date=${dateStr}`, 3);
     const scheduled = chores.find((c: any) => c.title === 'E2E Approval Test');
     expect(scheduled).toBeTruthy();

--- a/e2e/tests/chore-completion.spec.ts
+++ b/e2e/tests/chore-completion.spec.ts
@@ -2,21 +2,28 @@ import { test, expect } from '@playwright/test';
 import { selectUser } from './helpers/setup';
 
 test.describe('Chore Completion', () => {
-  test('completing a chore shows checkmark and updates points', async ({ page }) => {
+  // "Practice Piano" is chosen deliberately: it is a daily chore for Emma with
+  // no `available_at` / `due_by` window in config.example.yaml, so it is never
+  // locked or expired regardless of what time the suite runs. It is also the
+  // only chore in this spec, so it does not race with dashboard-views.spec.ts
+  // (which toggles "Make Bed" for the same user against the shared database).
+  // Do not swap this for a time-windowed chore such as "Brush Teeth (Morning)"
+  // — that one is locked before 07:00 local and the complete button is
+  // replaced by a countdown, which fails the test on any early-morning run.
+  const CHORE = 'Practice Piano';
+
+  test('completing a chore toggles it to the completed state', async ({ page }) => {
     await selectUser(page, 'Emma');
 
     // Wait for dashboard to load with chores
     await expect(page.locator('body')).toContainText('pts', { timeout: 10_000 });
 
-    // Get initial points display
-    const pointsText = await page.getByText(/\d+ pts/i).first().textContent();
-    const initialPoints = parseInt(pointsText?.match(/(\d+)/)?.[1] || '0');
-
-    // Find "Brush Teeth (Morning)" chore card
-    const choreCard = page.locator('xpath=//div[contains(@class, "choreCard")][.//text()[contains(., "Brush Teeth (Morning)")]]').first();
+    const choreCard = page
+      .locator(`xpath=//div[contains(@class, "choreCard")][.//text()[contains(., "${CHORE}")]]`)
+      .first();
     await expect(choreCard).toBeVisible({ timeout: 10_000 });
 
-    // If it was already completed by another parallel test, uncomplete it first
+    // The suite shares one database, so reset to a known state first.
     const markIncompleteBtn = choreCard.locator('button[aria-label="Mark incomplete"]');
     if (await markIncompleteBtn.isVisible().catch(() => false)) {
       await markIncompleteBtn.click();
@@ -24,10 +31,13 @@ test.describe('Chore Completion', () => {
     }
 
     // Click mark complete
-    const markCompleteBtn = choreCard.locator('button[aria-label="Mark complete"]');
-    await markCompleteBtn.click();
+    await choreCard.locator('button[aria-label="Mark complete"]').click();
 
     // Verify the chore shows as completed (button changes to "Mark incomplete")
     await expect(choreCard.locator('button[aria-label="Mark incomplete"]')).toBeVisible({ timeout: 5_000 });
+
+    // Undo, so re-runs against a reused database start from the same state.
+    await choreCard.locator('button[aria-label="Mark incomplete"]').click();
+    await expect(choreCard.locator('button[aria-label="Mark complete"]')).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/e2e/tests/helpers/setup.ts
+++ b/e2e/tests/helpers/setup.ts
@@ -39,3 +39,17 @@ export async function apiGet(page: Page, path: string, userId = 1) {
   expect(resp.ok()).toBeTruthy();
   return resp.json();
 }
+
+/**
+ * Today's date as YYYY-MM-DD in the *local* timezone.
+ *
+ * The Go server decides what "today" means using its own local clock, so tests
+ * must ask for the same day. `new Date().toISOString().slice(0, 10)` returns
+ * the UTC date, which is a different day from local for much of the world —
+ * under TZ=Asia/Tokyo it asks the server for yesterday, and lookups for
+ * chores scheduled "today" come back empty.
+ */
+export function localDateStr(d = new Date()) {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}

--- a/e2e/tests/points.spec.ts
+++ b/e2e/tests/points.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loginAsAdmin, selectUser, apiGet } from './helpers/setup';
+import { loginAsAdmin, selectUser, apiGet, localDateStr } from './helpers/setup';
 
 test.describe('Points System', () => {
   test('admin can manually adjust points via API', async ({ page }) => {
@@ -21,7 +21,7 @@ test.describe('Points System', () => {
 
   test('completing a chore creates a point transaction', async ({ page }) => {
     // Complete a chore via API and verify points transaction is created
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDateStr();
     const chores = await apiGet(page, `/users/3/chores?view=daily&date=${today}`, 3);
 
     // Find an incomplete required chore so points are awarded immediately without gating


### PR DESCRIPTION
Fixes the failing e2e test from #61 — and two more with the same defect that surfaced while verifying the fix.

## What was wrong

Three tests depended on the wall clock and the machine's timezone. They pass in CI (UTC, mid-afternoon) and on a developer machine during working hours, which is exactly why this went unnoticed for so long.

**1. `chore-completion.spec.ts` — locked chore before 07:00**

It targeted `Brush Teeth (Morning)`, seeded with `available_at: "07:00"`. Before 07:00 local the server marks the chore unavailable, [Dashboard.tsx:783](web/src/pages/Dashboard.tsx#L783) replaces the complete button with a countdown box, and the test times out waiting for `button[aria-label="Mark complete"]`.

Reproduced deterministically — no waiting until 6am:

```bash
cd e2e && TZ=Asia/Tokyo npx playwright test tests/chore-completion.spec.ts
```

**2. `approvals.spec.ts` and `points.spec.ts` — UTC vs local date**

Both built "today" with `toISOString().slice(0, 10)`, which is the **UTC** date, while the schedule was created from the **local** weekday (`getDay()`) and the Go server resolves "today" from its own local clock. East of UTC after 15:00 the test asked the server for a different day than the one it had just scheduled, so the chore lookup returned nothing and `expect(scheduled).toBeTruthy()` failed.

## Fixes

- Switched the completion test to **`Practice Piano`** — a daily chore for Emma with no `available_at`/`due_by`, so it is never locked or expired. It is also untouched by every other spec, so it no longer races with `dashboard-views.spec.ts` over `Make Bed` on the shared database. A comment records why, because the previous *two* chore choices both hit a version of this.
- Added a shared `localDateStr()` helper and used it in both date-sensitive specs.
- Minor: the completion test now restores state on the way out, the dead `initialPoints` variable is gone, and the title says what it actually asserts (it never checked points).

## Verification

Full suite, **64/64 in every zone** — spanning 02:00 to 23:00 and two different weekdays:

| TZ | Local time | Result |
|---|---|---|
| America/Los_Angeles | Wed 10:36 | 64 passed |
| UTC | Wed 17:37 | 64 passed |
| Pacific/Honolulu | Wed 07:37 | 64 passed |
| Asia/Tokyo | Thu 02:36 | 64 passed |
| Asia/Kolkata | Wed 23:07 | 64 passed |
| Pacific/Kiritimati | Thu 07:38 | 64 passed |

`Asia/Tokyo` failed before this change.

## Follow-up, not fixed here

The same UTC-vs-local date bug exists in application code — [Reports.tsx:95](web/src/pages/Reports.tsx#L95), [Reports.tsx:99](web/src/pages/Reports.tsx#L99) and [ScheduleManager.tsx:31](web/src/components/admin/ScheduleManager.tsx#L31) all use `toISOString().slice(0, 10)` against a server that thinks in local time. That is a user-visible bug (wrong day's report near midnight), not a test bug, so it belongs in its own change.

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)