### PR TITLE
fix(security): resolve three code scanning alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   API_IMAGE: ghcr.io/liftedkilt/openchore/api

--- a/internal/api/chores.go
+++ b/internal/api/chores.go
@@ -550,13 +550,11 @@ func (h *ChoreHandler) Complete(w http.ResponseWriter, r *http.Request) {
 	var aiConfidence float64
 	if req.PhotoURL != "" && h.reviewer != nil {
 		aiEnabled, _ := h.store.GetSetting(r.Context(), "ai_enabled")
-		if aiEnabled == "true" {
-			photoPath := req.PhotoURL
-			// Convert relative URL to file path
-			if len(photoPath) > 0 && photoPath[0] == '/' {
-				photoPath = "data" + photoPath // /uploads/x.jpg -> data/uploads/x.jpg
-			}
-
+		photoPath, pathErr := resolveUploadPath(req.PhotoURL)
+		if pathErr != nil {
+			log.Printf("ai: skipping review: %v", pathErr)
+		}
+		if aiEnabled == "true" && pathErr == nil {
 			thresholdStr, _ := h.store.GetSetting(r.Context(), "ai_auto_approve_threshold")
 			threshold := 0.85
 			if t, err := strconv.ParseFloat(thresholdStr, 64); err == nil && t > 0 {
@@ -1083,9 +1081,10 @@ func (h *ChoreHandler) TestAIReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	photoPath := req.PhotoURL
-	if len(photoPath) > 0 && photoPath[0] == '/' {
-		photoPath = "data" + photoPath
+	photoPath, err := resolveUploadPath(req.PhotoURL)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid photo_url")
+		return
 	}
 
 	t0 := time.Now()

--- a/internal/api/uploads.go
+++ b/internal/api/uploads.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -80,4 +81,23 @@ func (h *ChoreHandler) UploadPhoto(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
 		"url": "/uploads/" + filename,
 	})
+}
+
+// resolveUploadPath converts a stored photo URL (e.g. "/uploads/123_upload.jpg")
+// into a path on disk inside uploadDir. Only plain filenames within the uploads
+// directory are accepted, so user-supplied values can't escape it.
+func resolveUploadPath(photoURL string) (string, error) {
+	name := strings.TrimPrefix(photoURL, "/uploads/")
+	if name == photoURL {
+		name = strings.TrimPrefix(photoURL, "uploads/")
+		if name == photoURL {
+			return "", fmt.Errorf("photo url %q is not an upload", photoURL)
+		}
+	}
+	// filepath.Base strips any directory traversal ("../", nested paths).
+	name = filepath.Base(filepath.Clean("/" + name))
+	if name == "." || name == string(filepath.Separator) || name == "" {
+		return "", fmt.Errorf("photo url %q has no filename", photoURL)
+	}
+	return filepath.Join(uploadDir, name), nil
 }


### PR DESCRIPTION
Closes the three open code scanning alerts.

## `go/path-injection` (high) — `internal/ai/reviewer.go:29`

`photo_url` from the request body was turned into a disk path with a bare `"data" + photoURL` concatenation and handed to `os.Open`, so `/uploads/../../etc/passwd` escaped the uploads directory.

- New `resolveUploadPath` in `internal/api/uploads.go` requires an `/uploads/` prefix, then `filepath.Base(filepath.Clean(...))` strips any traversal before joining to `uploadDir`.
- `Complete` resolves the path up front; a bad URL logs and skips AI review rather than failing the completion, matching the existing "AI unavailable → proceed normally" behavior.
- `TestAIReview` returns `400 invalid photo_url`, since that endpoint's only job is the review.

## `actions/missing-workflow-permissions` (medium) ×2 — `.github/workflows/build.yml`

Added a top-level `permissions: contents: read`. The three image-push jobs keep their own `contents: read` / `packages: write` overrides, so pushing to ghcr.io is unaffected.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)